### PR TITLE
allow runtime config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,55 @@
 # ---- Base Node ----
-  FROM node:20.18.0-alpine3.20 AS base
-  WORKDIR /usr/src/app
+FROM node:20.18.0-alpine3.20 AS base
+WORKDIR /usr/src/app
 
-  # Copy project file
-  COPY ../package*.json ./
+# Copy project file
+COPY ../package*.json ./
 
-  # ---- Dependencies ----
-  FROM base AS dependencies
-  WORKDIR /usr/src/app
+# ---- Dependencies ----
+FROM base AS dependencies
+WORKDIR /usr/src/app
 
-  # Install production dependencies
-  RUN ls -al
+# Install production dependencies
+RUN npm install
+RUN npm install -g @quasar/cli
 
-  RUN npm install
-  RUN npm install -g @quasar/cli
+# ---- Copy Files/Build ----
+FROM dependencies AS build
+# Copy app files
+COPY . .
 
-  # ---- Copy Files/Build ----
-  FROM dependencies AS build
-  # Copy app files
-  COPY . .
+# Build app
+RUN quasar build
 
-  # Build app
-  RUN quasar build
+# # Remove devDependencies
+RUN npm prune --production
 
-  # # Remove devDependencies
-  RUN npm prune --production
+# ---- Release ----
+FROM base AS release
+COPY --from=dependencies /usr/src/app/node_modules ./node_modules
+COPY --from=build /usr/src/app/dist ./dist
 
-  # ---- Release ----
-  FROM base AS release
-  # Copy production dependencies
-  COPY --from=dependencies /usr/src/app/node_modules ./node_modules
-  # Copy build files from build stage
-  COPY --from=build /usr/src/app/dist ./dist
+# Install envsubst utility
+RUN apk add --no-cache gettext
 
-  RUN npm install -g @quasar/cli
+# Create template from the built index.html
+RUN cp ./dist/spa/index.html ./dist/spa/index.html.template
 
-  EXPOSE 9005
-  CMD [ "quasar", "serve", "--history", "--port", "9005", "./dist/spa" ]
+# Modify the template to include our config script
+RUN sed -i 's/<head>/<head><script>window.APP_CONFIG = {\
+  APP_API_URL: "${APP_API_URL}",\
+  APP_TENANT_ID: "${APP_TENANT_ID}",\
+  APP_HUBSPOT_PORTAL_ID: "${APP_HUBSPOT_PORTAL_ID}",\
+  APP_HUBSPOT_FORM_ID: "${APP_HUBSPOT_FORM_ID}",\
+  NODE_ENV: "${NODE_ENV}"\
+};<\/script>/' ./dist/spa/index.html.template
+
+# Add entrypoint script
+COPY docker-entrypoint.sh /
+RUN chmod +x /docker-entrypoint.sh
+
+RUN npm install -g @quasar/cli
+
+EXPOSE 9005
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD [ "quasar", "serve", "--history", "--port", "9005", "./dist/spa" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Replace environment variables in index.html
+envsubst < ./dist/spa/index.html.template > ./dist/spa/index.html
+
+# Execute CMD
+exec "$@"

--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -21,7 +21,8 @@ export default configure((ctx) => {
     boot: [
       'axios',
       'analytics',
-      'global-components'
+      'global-components',
+      'config'
     ],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#css

--- a/src/boot/config.js
+++ b/src/boot/config.js
@@ -1,0 +1,3 @@
+export default async ({ app }) => {
+  app.config.globalProperties.$config = window.APP_CONFIG
+}


### PR DESCRIPTION
Method to allow passing APP_API_URL and other vars at runtime. At container runtime, create an index.html containing expanded environment vars, which have been injected into the container environment. A boot method reads the config from the index and saves it internally when the app starts.  

Tested as working at https://platform.openmeet.net and https://platform-dev.openmeet.net