### PR TITLE
permission system refinements for group messaging functionality:

### DIFF
--- a/src/components/group/GroupStickyComponent.vue
+++ b/src/components/group/GroupStickyComponent.vue
@@ -89,7 +89,7 @@ const onLeaveGroup = () => {
               icon="sym_r_settings"
               @click="router.push({ name: 'DashboardGroupPage', params: { slug: group?.slug } })" />
             <MenuItemComponent data-cy="send-admin-message-button"
-              v-if="useGroupStore().getterUserHasPermission(GroupPermission.ManageMembers)"
+              v-if="useGroupStore().getterUserHasPermission(GroupPermission.ContactMembers)"
               label="Send Message to Members"
               icon="sym_r_send"
               @click="onSendAdminMessage" />
@@ -105,7 +105,9 @@ const onLeaveGroup = () => {
           v-else-if="useGroupStore().getterUserIsGroupMember() && !useGroupStore().getterUserHasRole(GroupRole.Owner)"
           align="center" no-caps :label="`You're a ${group?.groupMember?.groupRole.name}`">
           <q-list>
-            <MenuItemComponent data-cy="contact-admins-button" label="Contact Admins" icon="sym_r_mail"
+            <MenuItemComponent data-cy="contact-admins-button"
+              v-if="useGroupStore().getterUserHasPermission(GroupPermission.ContactAdmins)"
+              label="Contact Admins" icon="sym_r_mail"
               @click="onContactAdmins" />
             <MenuItemComponent data-cy="leave-group-button" label="Leave this group" icon="sym_r_report"
               @click="onLeaveGroup" />

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -96,6 +96,8 @@ export enum GroupPermission {
   CreateEvent = 'CREATE_EVENT',
   MessageDiscussion = 'MESSAGE_DISCUSSION',
   MessageMember = 'MESSAGE_MEMBER',
+  ContactMembers = 'CONTACT_MEMBERS',
+  ContactAdmins = 'CONTACT_ADMINS',
   SeeMembers = 'SEE_MEMBERS',
   SeeEvents = 'SEE_EVENTS',
   SeeDiscussions = 'SEE_DISCUSSIONS',


### PR DESCRIPTION
- Added new permissions: ContactMembers and ContactAdmins to GroupPermission enum
- Updated permission checks: Changed "Send Message to Members" button from ManageMembers to ContactMembers permission
- Added permission gate: "Contact Admins" button now requires ContactAdmins permission instead of being always visible

These changes create more granular control over who can contact different types of group members.