### PR TITLE
Add cancelled event status badges across event displays

### DIFF
--- a/src/components/event/EventsItemComponent.vue
+++ b/src/components/event/EventsItemComponent.vue
@@ -49,6 +49,14 @@ const formatSeriesSlug = (slug: string): string => {
       <div class="text-caption badges-container">
         <q-badge>{{ event.type }}</q-badge>
         <q-badge
+          v-if="event.status === 'cancelled'"
+          color="red"
+          class="q-ml-sm"
+        >
+          <q-icon name="sym_r_cancel" size="xs" class="q-mr-xs" />
+          Cancelled
+        </q-badge>
+        <q-badge
           v-if="event.sourceType"
           :color="getSourceColor(event.sourceType)"
           class="q-ml-sm"

--- a/src/components/group/GroupAboutEventsComponent.vue
+++ b/src/components/group/GroupAboutEventsComponent.vue
@@ -3,6 +3,7 @@ import { formatDate } from '../../utils/dateUtils'
 import { EventEntity } from '../../types'
 import { useNavigation } from '../../composables/useNavigation'
 import SubtitleComponent from '../common/SubtitleComponent.vue'
+import NoContentComponent from '../global/NoContentComponent.vue'
 import { computed } from 'vue'
 
 const { navigateToEvent } = useNavigation()
@@ -35,7 +36,13 @@ const sortedEvents = computed(() => {
           <q-icon name="sym_r_event" color="primary" size="md" />
         </q-item-section>
         <q-item-section>
-          <q-item-label>{{ event.name }}</q-item-label>
+          <q-item-label>
+            {{ event.name }}
+            <q-badge v-if="event.status === 'cancelled'" color="red" class="q-ml-sm">
+              <q-icon name="sym_r_cancel" size="xs" class="q-mr-xs" />
+              Cancelled
+            </q-badge>
+          </q-item-label>
           <q-item-label caption>
             {{ formatDate(event.startDate) }}
           </q-item-label>

--- a/src/composables/useNavigation.ts
+++ b/src/composables/useNavigation.ts
@@ -15,14 +15,15 @@ export function useNavigation () {
       return
     }
 
-    // Always navigate to the public event page when an event is published
-    if (event.status === 'published') {
-      console.log('Event is published, redirecting to public event page')
+    // Always navigate to the public event page when an event is published or cancelled
+    // Cancelled events should be viewable by the public, not editable
+    if (event.status === 'published' || event.status === 'cancelled') {
+      console.log('Event is published or cancelled, redirecting to public event page')
       router.push({ name: 'EventPage', params: { slug: event.slug } })
       return
     }
 
-    // For non-published events, check if we're in dashboard context
+    // For non-published events (draft, pending), check if we're in dashboard context
     const currentPath = router.currentRoute.value.path
     const isDashboardContext = currentPath.includes('/dashboard')
 

--- a/src/pages/EventPage.vue
+++ b/src/pages/EventPage.vue
@@ -38,6 +38,12 @@
                   }}</span>
                 </span>
                 <div class="text-h6 text-bold">{{ event.name }}</div>
+                <div v-if="event.status === 'cancelled'" class="q-mt-sm">
+                  <q-badge color="red" class="text-bold">
+                    <q-icon name="sym_r_cancel" size="xs" class="q-mr-xs" />
+                    Event Cancelled
+                  </q-badge>
+                </div>
                 <div v-if="isTemplateView" class="text-caption text-blue">
                   <q-icon name="sym_r_info" size="xs" class="q-mr-xs" />
                   This is a future occurrence of this event. Editing or adding attendees will create a scheduled event.


### PR DESCRIPTION
The changes add visual indicators for cancelled events:
- EventsItemComponent: Red "Cancelled" badge with cancel icon in event cards
- GroupAboutEventsComponent: Cancelled badge next to event names in group event lists
- EventPage: Prominent "Event Cancelled" badge on individual event pages
- useNavigation: Allow navigation to cancelled events (treat as published for viewing)