### PR TITLE
Update RSVP UI to allow separate "attending" and "not attending" options

### DIFF
--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -25,6 +25,13 @@ export const chatApi = {
   getEventMessages: (eventSlug: string, limit?: number, from?: string): Promise<AxiosResponse<{ messages: MatrixMessage[], end: string, roomId?: string }>> =>
     api.get(`/api/chat/event/${eventSlug}/messages`, { params: { limit, from } }),
 
+  joinEventChatRoom: (eventSlug: string): Promise<AxiosResponse<{
+    success: boolean;
+    roomId?: string;
+    message?: string;
+  }>> =>
+    api.post(`/api/chat/event/${eventSlug}/join`, {}),
+
   addMemberToEventDiscussion: (eventSlug: string, userSlug: string): Promise<AxiosResponse<{
     success?: boolean;
     roomId?: string;

--- a/src/stores/event-store.ts
+++ b/src/stores/event-store.ts
@@ -331,6 +331,34 @@ export const useEventStore = defineStore('event', {
       }
     },
 
+    async actionJoinEventChatRoom () {
+      try {
+        if (this.event?.slug) {
+          console.log(`Attempting to join chat room for event ${this.event.slug}`)
+          const response = await chatApi.joinEventChatRoom(this.event.slug)
+          console.log(`Successfully joined chat room for event`, response.data)
+
+          // Check if the response includes a roomId
+          if (response.data && response.data.roomId) {
+            console.log(`Received roomId from joinEventChatRoom: ${response.data.roomId}`)
+            // Save the roomId directly to the event object if provided
+            if (this.event) {
+              this.event.roomId = response.data.roomId
+              console.log(`Updated event with roomId: ${this.event.roomId}`)
+            }
+          } else {
+            console.warn('No roomId returned from joinEventChatRoom API call')
+          }
+
+          return response.data
+        }
+        return null
+      } catch (error) {
+        console.error('Error joining event chat room:', error)
+        throw error
+      }
+    },
+
     async actionAddMemberToEventDiscussion (userSlug: string) {
       try {
         if (this.event?.slug) {


### PR DESCRIPTION
- Add joinEventChatRoom API method for Matrix chat room joining
- Replace single RSVP button with separate "Attending" and "Not attending" buttons when no RSVP exists
- Add handleNotAttending function to set attendee status to cancelled
- Allow users with cancelled status to access and participate in event chat discussions
- Update chat room initialization logic to include cancelled attendees alongside confirmed ones
- Modify discussion permissions to grant read/write access to both confirmed and cancelled attendees