### PR TITLE
sort series dates for display

### DIFF
--- a/src/components/event/RecurrenceComponent.vue
+++ b/src/components/event/RecurrenceComponent.vue
@@ -388,7 +388,7 @@ const refreshOccurrencesPreview = async () => {
         date: occurrence.date,
         eventSlug: occurrence.event?.slug || null,
         materialized: occurrence.materialized
-      }))
+      })).sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
     } else {
       // For new series, we need to handle this differently
 
@@ -435,7 +435,7 @@ const refreshOccurrencesPreview = async () => {
         date: occurrence.date,
         eventSlug: null,
         materialized: false
-      }))
+      })).sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
 
       console.log('Received occurrences from temporary series API:', upcomingOccurrences.value)
     }


### PR DESCRIPTION
Sort order was slightly wrong when updating an event with recurrence, possibly listing vivified events first in the recurrence display