### PR TITLE
show canceled event state immediatly

### DIFF
--- a/src/composables/useEventDialog.ts
+++ b/src/composables/useEventDialog.ts
@@ -8,11 +8,13 @@ import EventAttendPendingDialogComponent from '../components/event/dialogs/Event
 import EventAttendRejectedDialogComponent from '../components/event/dialogs/EventAttendRejectedDialogComponent.vue'
 import EventAttendeesNoRightsDialogComponent from '../components/event/dialogs/EventAttendeesNoRightsDialogComponent.vue'
 import { useRouter } from 'vue-router'
+import { useEventStore } from '../stores/event-store'
 
 export function useEventDialog () {
   const $q = useQuasar()
   const { success } = useNotification()
   const router = useRouter()
+  const eventStore = useEventStore()
 
   const openDeleteGroupDialog = () => {
     return $q.dialog({
@@ -107,6 +109,8 @@ export function useEventDialog () {
     }).onOk(() => {
       return eventsApi.update(event.slug, { status: EventStatus.Cancelled } as Partial<EventEntity>).then(() => {
         success('Event cancelled!')
+        // Refresh the event data to update the UI with the cancelled status
+        eventStore.actionGetEventBySlug(event.slug)
       })
     })
   }


### PR DESCRIPTION
Now when users cancel an event on the EventPage.vue, the page will immediately update to reflect the cancelled state without requiring a manual page reload. The cancelled event badge will appear and the UI will adjust accordingly.