### PR TITLE
Fix timeline sync loss after room switching

### DIFF
--- a/src/components/chat/MatrixChatInterface.vue
+++ b/src/components/chat/MatrixChatInterface.vue
@@ -1922,6 +1922,13 @@ const handleInvalidTokenRecovery = () => {
 // Token error event handler (handles real-time token failures)
 const handleTokenError = (event) => {
   logger.debug('🚫 Matrix token error received:', event.detail)
+
+  // If this is just a notification during SDK-managed refresh, don't change UI
+  if (event.detail?.action === 'notification_only' && event.detail?.sdkManagedTokenRefresh) {
+    logger.debug('📢 Token error is notification-only during SDK refresh - preserving UI state')
+    return
+  }
+
   logger.debug('🔧 Current UI state before token error handling:', {
     isConnected: isConnected.value,
     lastAuthError: lastAuthError.value,

--- a/src/composables/useMatrixTimeline.ts
+++ b/src/composables/useMatrixTimeline.ts
@@ -282,12 +282,15 @@ export function useMatrixTimeline (options: TimelineOptions = {}) {
         })
       }
 
-      // If we're not at the live end, we need to move the timeline window to include new events
-      if (timelineWindow.value && !isAtLiveEnd.value) {
-        logger.debug('📍 Not at live end, moving timeline window to include new event')
+      // Always try to advance timeline window for new events (Element Web pattern)
+      if (timelineWindow.value) {
+        if (!isAtLiveEnd.value) {
+          logger.debug('📍 Not at live end, moving timeline window to include new event')
+        }
         try {
-          // Try to paginate forward to include the new event
-          const success = await timelineWindow.value.paginate(EventTimeline.FORWARDS, 50)
+          // Element Web calls paginate(FORWARDS, 1, false) for live events
+          // This advances the timeline window to include the new event
+          const success = await timelineWindow.value.paginate(EventTimeline.FORWARDS, 1, false)
           logger.debug('📍 Timeline pagination result:', success)
         } catch (error) {
           logger.warn('⚠️ Failed to paginate timeline forward:', error)

--- a/src/services/MatrixClientManager.ts
+++ b/src/services/MatrixClientManager.ts
@@ -1350,22 +1350,21 @@ export class MatrixClientManager {
 
     // Store session logged out handler for cleanup (Element Web pattern)
     this.sessionLoggedOutHandler = (error: SdkMatrixError) => {
-      logger.warn('Matrix session logged out - SDK determined token refresh failed', error)
+      logger.warn('Matrix session logged out event received - letting SDK handle token refresh', error)
 
-      // Emit token error event for UI components to react (following our existing pattern)
+      // Just emit notification event for UI components
+      // Don't destroy the client - let the SDK handle token refresh internally
       const tokenErrorEvent = new CustomEvent('matrix:tokenError', {
         detail: {
           error,
           context: 'matrix_session_logged_out',
-          sdkManagedTokenRefresh: true
+          sdkManagedTokenRefresh: true,
+          action: 'notification_only'
         }
       })
       window.dispatchEvent(tokenErrorEvent)
 
-      // Clear credentials to force re-authentication
-      this.clearClientAndCredentials().catch(clearError => {
-        logger.error('❌ Failed to clear credentials after session logged out:', clearError)
-      })
+      logger.debug('📢 SessionLoggedOut event handled - client preserved for SDK token refresh')
     }
 
     // Only essential listeners for performance


### PR DESCRIPTION
Timeline events were not appearing in UI after room navigation because:
1. Matrix client was being destroyed during normal token refresh cycles
2. Timeline window wasn't advancing to include new events

Changes:
- Remove aggressive client destruction in sessionLoggedOutHandler during token refresh
- Ignore notification-only token errors to prevent unnecessary UI state changes
- Always paginate timeline window forward when new events arrive (Element Web pattern)

This ensures timeline listeners stay connected and new messages appear immediately instead of requiring page refresh.