### PR TITLE
Fix Inter font loading timeout by switching to swap display

### DIFF
--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=optional');
+@import url('https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,100..900;1,14..32,100..900&display=swap');
 
 $typography-font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif !default;
 


### PR DESCRIPTION
- Change font-display from 'optional' to 'swap' to prevent timeout errors
- Improves font loading performance and user experience