### PR TITLE
Fix Matrix connect button not showing when tokens expire

### DIFF
--- a/src/components/chat/MatrixNativeChatOrchestrator.vue
+++ b/src/components/chat/MatrixNativeChatOrchestrator.vue
@@ -262,15 +262,34 @@ const $q = useQuasar()
 // Auth store for simple token checking
 const authStore = useAuthStore()
 
-// Simple, fast token check - no complex async logic or race conditions
+// Check if user needs to login - considers both stored tokens and actual client state
 const needsLogin = computed(() => {
   // Wait for auth store to be ready
   if (!authStore.isInitialized || !authStore.user?.slug) {
     return false // Show loading instead of connect button until we're sure
   }
 
-  // Simple sync check: do we have any Matrix tokens stored?
-  return !hasStoredMatrixTokens(authStore.user.slug)
+  // First check: do we have any Matrix tokens stored?
+  const hasTokens = hasStoredMatrixTokens(authStore.user.slug)
+
+  // If no tokens at all, definitely need login
+  if (!hasTokens) {
+    return true
+  }
+
+  // If we have tokens, also check if the Matrix client is actually available
+  // This catches cases where tokens exist but are expired/invalid
+  const clientAvailable = matrixClientManager.isClientAvailable()
+  const clientInitializing = matrixClientManager.isClientInitializing()
+
+  // If client is initializing, don't show connect button yet
+  if (clientInitializing) {
+    return false
+  }
+
+  // If we have tokens but client is not available (and not initializing),
+  // it likely means authentication failed - show connect button
+  return !clientAvailable
 })
 
 // Keep the encryption logic from useMatrixEncryption but override needsLogin


### PR DESCRIPTION
When Matrix tokens expire but remain stored in localStorage, the needsLogin computed property only checked for token existence, not actual client authentication state. This left users in a broken state where 401 errors occurred but no "Connect to Matrix" button was shown.

Enhanced needsLogin logic to also check matrixClientManager isClientAvailable() state, ensuring the connect button appears when authentication fails even with stored (but expired) tokens.

Fixes the scenario where tokens exist but Matrix client reports M_UNKNOWN_TOKEN errors, providing users a way to re-authenticate.