### PR TITLE
Replace ngrok tunnels with FRP reverse proxy

### DIFF
--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -93,10 +93,10 @@ export default configure((ctx) => {
           "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://accounts.google.com https://*.googleusercontent.com https://*.posthog.com",
           "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com",
           "img-src 'self' data: https: blob: https://*.google.com https://*.googleusercontent.com",
-          "media-src 'self' blob: data: https://matrix-dev.openmeet.net https://matrix.openmeet.net https://om-matrix.ngrok.app",
+          "media-src 'self' blob: data: https://matrix-dev.openmeet.net https://matrix.openmeet.net https://matrix.dev.openmeet.net",
           "font-src 'self' https://fonts.gstatic.com",
-          "frame-src 'self' https://accounts.google.com https://play.google.com https://*.google.com https://accounts.youtube.com http://localhost:8448 https://localhost:8448 http://localhost:3000 https://localhost:3000 https://matrix-dev.openmeet.net https://matrix.openmeet.net https://api-dev.openmeet.net https://api.openmeet.net https://om-api.ngrok.app https://om-mas.ngrok.app https://om-matrix.ngrok.app",
-          "connect-src 'self' blob: http://localhost:* https://localhost:* http://127.0.0.1:* https://127.0.0.1:* http://0.0.0.0:* https://0.0.0.0:* https://accounts.google.com https://*.google.com https://play.google.com https://api-dev.openmeet.net https://api.openmeet.net wss://api-dev.openmeet.net wss://api.openmeet.net https://*.amazonaws.com https://*.openstreetmap.org https://*.posthog.com https://api.hsforms.com https://om-api.ngrok.app wss://om-api.ngrok.app https://om-mas.ngrok.app wss://om-mas.ngrok.app https://om-matrix.ngrok.app wss://om-matrix.ngrok.app https://matrix-dev.openmeet.net wss://matrix-dev.openmeet.net *",
+          "frame-src 'self' https://accounts.google.com https://play.google.com https://*.google.com https://accounts.youtube.com http://localhost:8448 https://localhost:8448 http://localhost:3000 https://localhost:3000 https://matrix-dev.openmeet.net https://matrix.openmeet.net https://api-dev.openmeet.net https://api.openmeet.net https://api.dev.openmeet.net https://mas.dev.openmeet.net https://matrix.dev.openmeet.net",
+          "connect-src 'self' blob: http://localhost:* https://localhost:* http://127.0.0.1:* https://127.0.0.1:* http://0.0.0.0:* https://0.0.0.0:* https://accounts.google.com https://*.google.com https://play.google.com https://api-dev.openmeet.net https://api.openmeet.net wss://api-dev.openmeet.net wss://api.openmeet.net https://*.amazonaws.com https://*.openstreetmap.org https://*.posthog.com https://api.hsforms.com https://api.dev.openmeet.net https://mas.dev.openmeet.net https://matrix.dev.openmeet.net https://matrix-dev.openmeet.net wss://matrix-dev.openmeet.net *",
           "object-src 'none'",
           "base-uri 'self'"
         ].join('; '))
@@ -174,9 +174,9 @@ export default configure((ctx) => {
     devServer: {
       // https: Boolean(process.env.DEV_SERVER_HTTPS),
       port: Number(process.env.APP_DEV_SERVER_PORT) || 8080,
-      open: true, // opens browser window automatically
+      open: false, // opens browser window automatically
       host: '0.0.0.0', // Allow external connections
-      allowedHosts: ['localhost', '127.0.0.1', 'om-platform.ngrok.app'], // Allow ngrok
+      allowedHosts: ['localhost', '127.0.0.1', 'platform.dev.openmeet.net'],
       proxy: {
         '/sitemap.xml': {
           target: process.env.APP_API_URL || 'http://localhost:3000',

--- a/src/components/auth/LoginComponent.vue
+++ b/src/components/auth/LoginComponent.vue
@@ -117,23 +117,10 @@ const handlePostLoginRedirect = (): void => {
       if (Date.now() - oidcData.timestamp < maxAge) {
         console.log('🔄 OIDC Flow: Continuing OIDC flow after login, redirecting to:', oidcData.returnUrl)
 
-        // Get the user's JWT token to include in the redirect
-        const token = authStore.token
-        if (token) {
-          const url = new URL(oidcData.returnUrl)
-          url.searchParams.set('user_token', token)
-          console.log('🔄 OIDC Flow: Added user token to OIDC redirect')
-
-          // Clear the stored data
-          localStorage.removeItem('oidc_flow_data')
-
-          // Redirect to the OIDC auth endpoint with token
-          window.location.href = url.toString()
-          return
-        }
-
-        // Fallback: redirect without token
+        // Clear the stored data
         localStorage.removeItem('oidc_flow_data')
+
+        // Redirect to the OIDC auth endpoint (uses session cookies for auth)
         window.location.href = oidcData.returnUrl
         return
       } else {

--- a/test/cypress/e2e/matrix-oidc-flow.cy.ts
+++ b/test/cypress/e2e/matrix-oidc-flow.cy.ts
@@ -134,8 +134,8 @@ describe('Matrix OIDC Flow - Reference Test', () => {
 
     // Step 2: Wait for and handle MAS consent or direct platform return
     cy.url({ timeout: 20000 }).should('satisfy', (url) => {
-      const platformMatch = url.includes('om-platform.ngrok.app') || url.includes('localhost') || url.includes('/groups/')
-      const masMatch = url.includes('om-mas.ngrok.app') || url.includes('mas-dev.openmeet.net')
+      const platformMatch = url.includes('platform.dev.openmeet.net') || url.includes('localhost') || url.includes('/groups/')
+      const masMatch = url.includes('mas.dev.openmeet.net') || url.includes('mas-dev.openmeet.net')
       cy.log(`URL check - Platform: ${platformMatch}, MAS: ${masMatch}, URL: ${url}`)
       return platformMatch || masMatch
     })
@@ -147,7 +147,7 @@ describe('Matrix OIDC Flow - Reference Test', () => {
       cy.log(`Final URL for consent check: ${finalUrl}`)
 
       const isMasConsent = finalUrl.includes('consent') || finalUrl.includes('mas')
-      const isPlatformReturn = finalUrl.includes('/groups/') || finalUrl.includes('om-platform.ngrok.app')
+      const isPlatformReturn = finalUrl.includes('/groups/') || finalUrl.includes('platform.dev.openmeet.net')
 
       if (isMasConsent && !isPlatformReturn) {
         cy.log('🏛️ MAS consent/authorization page detected - handling consent')
@@ -180,7 +180,7 @@ describe('Matrix OIDC Flow - Reference Test', () => {
 
         // Wait for redirect back to platform
         cy.url({ timeout: 20000 }).should('satisfy', (url) => {
-          return url.includes('/groups/') || url.includes('om-platform.ngrok.app')
+          return url.includes('/groups/') || url.includes('platform.dev.openmeet.net')
         })
       } else if (isPlatformReturn) {
         cy.log('⚡ Already back on platform - no consent step needed')


### PR DESCRIPTION
Migrated local development tunneling from ngrok to FRP (Fast Reverse Proxy) deployed in our k8s cluster. This change reduces operational costs and allows us to use our own domain (*.dev.openmeet.net) instead of ngrok subdomains.

Benefits:
- Free and open-source (vs paid ngrok subscription)
- Uses existing SSL certificates and ALB infrastructure
- Custom domain improves cookie handling (all services under openmeet.net)
- Eliminates cross-origin cookie issues with SameSite=None

Changes:
- Updated OIDC discovery to use *.dev.openmeet.net domains
- Fixed cookie configuration to work with proper domain
- Improved OIDC redirect URL handling in controllers