### PR TITLE
fix: Matrix session persistence across OpenMeet logout/login cycles

### DIFF
--- a/src/components/event/EventMatrixChatComponent.vue
+++ b/src/components/event/EventMatrixChatComponent.vue
@@ -16,15 +16,20 @@ const event = computed(() => eventStore.event)
 const eventSlug = computed(() => {
   const routeSlug = route.params.slug as string
   const storeSlug = event.value?.slug
+
+  // FIX: Use route slug as source of truth, fallback to store for backward compat
+  // This prevents race conditions when navigating between events
+  const resolvedSlug = routeSlug || storeSlug
+
   console.log('🎯 EventMatrixChatComponent: Event slug resolution:', {
     routeSlug,
     storeEventSlug: storeSlug,
-    usingSlug: storeSlug || routeSlug,
+    usingSlug: resolvedSlug,
     match: routeSlug === storeSlug,
     timestamp: new Date().toISOString()
   })
-  // Using store event slug (original behavior before fix)
-  return storeSlug
+
+  return resolvedSlug
 })
 
 // Permissions for the discussion

--- a/src/services/__tests__/matrix-integration.vitest.test.ts
+++ b/src/services/__tests__/matrix-integration.vitest.test.ts
@@ -46,7 +46,8 @@ vi.mock('../../stores/auth-store', () => ({
   useAuthStore: vi.fn(() => ({
     user: { slug: 'test-user', email: 'test@example.com' },
     token: 'valid-token',
-    getUserSlug: 'test-user'
+    getUserSlug: 'test-user',
+    isInitialized: true
   }))
 }))
 

--- a/src/stores/auth-store.ts
+++ b/src/stores/auth-store.ts
@@ -146,11 +146,13 @@ export const useAuthStore = defineStore('authStore', {
     },
     async actionLogout () {
       return authApi.logout().finally(async () => {
-        // Clear Matrix session before clearing OpenMeet auth
+        // RULE: Only stop Matrix client on OpenMeet logout, but keep tokens/device ID
+        // This allows auto-reconnect on next login without re-consenting to MAS auth
+        // Matrix tokens are only cleared when user explicitly clicks "Clear Matrix Sessions"
         try {
-          await matrixClientManager.clearClientAndCredentials()
+          await matrixClientManager.clearClient()
         } catch (error) {
-          logger.warn('Failed to clear Matrix session during logout:', error)
+          logger.warn('Failed to stop Matrix client during logout:', error)
         }
 
         this.actionClearAuth()


### PR DESCRIPTION
Fixes issue where Matrix sessions required reconnection after each OpenMeet logout. Changes preserve Matrix tokens and device IDs on logout since Matrix has an independent OIDC session. Also fixes token refresh to save per-device instead of legacy per-user format, and resolves race condition in EventMatrixChatComponent where stale store data was used instead of route slug.