### PR TITLE
fix: lock Bluesky publishing toggle and visibility after event creation

### DIFF
--- a/src/components/event/EventFormBasicComponent.vue
+++ b/src/components/event/EventFormBasicComponent.vue
@@ -260,11 +260,24 @@
             <q-checkbox
               data-cy="event-publish-to-bluesky"
               v-model="publishToBluesky"
+              :disable="!!eventData.slug"
               label="Publish to Bluesky"
             />
-            <p class="text-caption q-mt-xs q-ml-md text-info" v-if="publishToBluesky">
+            <p class="text-caption q-mt-xs q-ml-md text-warning" v-if="!eventData.slug">
+              <q-icon name="sym_r_warning" size="xs" />
+              This choice cannot be changed after the event is created.
+            </p>
+            <p class="text-caption q-mt-xs q-ml-md text-info" v-if="publishToBluesky && !eventData.slug">
               <q-icon name="sym_r_info" size="xs" />
-              Bluesky events must be public. Private and authenticated events cannot be published to Bluesky.
+              Bluesky events must be public. The visibility will be locked to "The World".
+            </p>
+            <p class="text-caption q-mt-xs q-ml-md text-info" v-if="eventData.slug && eventData.sourceType === 'bluesky'">
+              <q-icon name="sym_r_info" size="xs" />
+              This event is published to Bluesky and will remain linked to the Bluesky post.
+            </p>
+            <p class="text-caption q-mt-xs q-ml-md text-grey-7" v-if="eventData.slug && eventData.sourceType !== 'bluesky'">
+              <q-icon name="sym_r_info" size="xs" />
+              This is a local-only event.
             </p>
           </div>
 
@@ -280,6 +293,7 @@
               emit-value
               map-options
               :options="visibilityOptions"
+              :disable="publishToBluesky"
               filled
             />
             <p class="text-caption q-mt-sm" v-if="eventData.visibility === EventVisibility.Private">


### PR DESCRIPTION
* Disable Bluesky toggle when editing existing events to prevent conversion
* Lock visibility dropdown to "Public" when Bluesky toggle is enabled
* Add warning that Bluesky publishing choice is permanent
* Show appropriate status messages for existing Bluesky and local events
    
    This prevents edge cases where converting local events to Bluesky events
    (or vice versa) after creation would cause duplicate or orphaned posts.

helps #233 