### PR TITLE
fix: prevent premature logout by enabling token refresh on expiry

### DIFF
--- a/quasar.config.ts
+++ b/quasar.config.ts
@@ -53,6 +53,7 @@ export default configure((ctx) => {
       'config',
       'tracing',
       'axios',
+      'auth-session', // Must come after axios since it depends on axios interceptor
       'analytics',
       'global-components',
       'posthog'


### PR DESCRIPTION
Fixes issue where users were logged out after JWT expiry (~30min) without attempting to use the refresh token (1d TTL). Changes include:

- Activate auth-session boot file for proactive token refresh during navigation
- Add token refresh attempt in initializeAuth() before clearing expired auth
- Consolidate router guards to avoid duplication and ensure proper execution order

This creates three layers of protection:
1. Proactive refresh during navigation (5 min before expiry)
2. Refresh on app initialization if token expired
3. Reactive refresh on API 401 errors (axios interceptor)

related to #240 