### PR TITLE
feat: migrate to GitOps workflow with ArgoCD

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -1,4 +1,4 @@
-name: Deploy Platform to Dev Environment
+name: Deploy Platform to Dev (GitOps)
 
 on:
   push:
@@ -24,131 +24,24 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Run Tests
+      - name: Run Linter
         run: npm run lint
 
       # Uncomment when unit tests are ready
       # - name: Run unit tests
       #   run: npm run test:unit:ci
 
-  build-deploy-to-dev:
-    runs-on: ubuntu-latest
-    needs: [test]
-    if: github.event_name == 'pull_request'
-
-    steps:
-      - name: Checkout Platform repository
-        uses: actions/checkout@v4
-
-      - name: Checkout infrastructure repository
-        if: github.actor != 'dependabot[bot]'
-        uses: actions/checkout@v4
-        with:
-          repository: openmeet-team/openmeet-infrastructure
-          path: openmeet-infrastructure
-          token: ${{ secrets.GH_PAT_INFRASTRUCTURE }}
-
-      - name: Configure AWS credentials
-        if: github.actor != 'dependabot[bot]'
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
-
-      - name: Login to Amazon ECR
-        if: github.actor != 'dependabot[bot]'
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Set image tags
-        run: |
-          echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-          echo "BRANCH_NAME=$(echo ${{ github.head_ref }} | sed 's/\//-/g')" >> $GITHUB_ENV
-          echo "IMAGE_TAG=pr-${{ github.event.pull_request.number }}-$(date +%Y%m%d%H%M%S)" >> $GITHUB_ENV
-
-      - name: Build, tag, and push image to Amazon ECR
-        if: github.actor != 'dependabot[bot]'
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: openmeet-ecr/openmeet-platform
-          GIT_REVISION: ${{ github.sha }}
-          GIT_BRANCH: ${{ github.ref_name }}
-        run: |
-          echo "Building image with tag: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-
-          APP_VERSION=$(node -p "require('./package.json').version")
-          docker buildx build --load \
-            --build-arg APP_VERSION="${APP_VERSION}" \
-            --build-arg COMMIT_SHA="${GITHUB_SHA}" \
-            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-
-          # Tag with PR-specific tag for reference
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:pr-$PR_NUMBER
-
-          # Push both tags
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:pr-$PR_NUMBER
-
-      - name: Install kubectl
-        if: github.actor != 'dependabot[bot]'
-        uses: azure/setup-kubectl@v3
-        with:
-          version: 'v1.30.1'
-
-      - name: Update kubeconfig
-        if: github.actor != 'dependabot[bot]'
-        run: aws eks update-kubeconfig --name openmeet-prod --region ${{ vars.AWS_REGION || 'us-east-1' }}
-
-      - name: Deploy to dev environment
-        if: github.actor != 'dependabot[bot]'
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: openmeet-ecr/openmeet-platform
-        run: |
-          # Apply the patch to the dev environment
-          cd openmeet-infrastructure
-
-          # First ensure namespace exists
-          kubectl apply -f k8s/environments/dev/namespace.yaml --validate=false
-
-          # Update the deployment with the new image
-          kubectl set image deployment/platform platform=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -n dev
-
-          # Update the infrastructure repository with the new image tag
-          sed -i "s|image: .*openmeet-ecr/openmeet-platform:.*|image: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|" k8s/environments/dev/kustomization.yaml
-
-          # Configure Git
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "GitHub Actions"
-
-          # Commit and push the changes
-          git add k8s/environments/dev/kustomization.yaml
-          git commit -m "Update Platform image to $IMAGE_TAG for PR #$PR_NUMBER"
-          git push origin main
-
-          # Wait for rollout to complete
-          kubectl rollout status deployment/platform -n dev
-
-  deploy-to-main:
+  build-and-deploy:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    outputs:
+      image_tag: ${{ steps.set-outputs.outputs.image_tag }}
 
     steps:
       - name: Checkout Platform repository
         uses: actions/checkout@v4
 
-      - name: Checkout infrastructure repository
-        if: github.actor != 'dependabot[bot]'
-        uses: actions/checkout@v4
-        with:
-          repository: openmeet-team/openmeet-infrastructure
-          path: openmeet-infrastructure
-          ref: main
-          token: ${{ secrets.GH_PAT_INFRASTRUCTURE }}
-
       - name: Configure AWS credentials
-        if: github.actor != 'dependabot[bot]'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -156,67 +49,46 @@ jobs:
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       - name: Login to Amazon ECR
-        if: github.actor != 'dependabot[bot]'
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: true
+
+      - name: Set image tag
+        id: set-outputs
+        run: |
+          echo "IMAGE_TAG=${{ github.sha }}" >> $GITHUB_ENV
+          echo "image_tag=${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: Build, tag, and push image to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: openmeet-ecr/openmeet-platform
-          IMAGE_TAG: ${{ github.sha }}
           GIT_REVISION: ${{ github.sha }}
           GIT_BRANCH: ${{ github.ref_name }}
         run: |
           echo "Building image with tag: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
-
           APP_VERSION=$(node -p "require('./package.json').version")
           docker buildx build --load \
             --build-arg APP_VERSION="${APP_VERSION}" \
             --build-arg COMMIT_SHA="${GITHUB_SHA}" \
             -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-
-          # Also tag as latest for main branch
-          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
-
-          # Push both tags
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+          # Tag as latest for main branch
+          docker tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
-      - name: Install kubectl
-        if: github.actor != 'dependabot[bot]'
-        uses: azure/setup-kubectl@v3
-        with:
-          version: 'v1.30.1'
-
-      - name: Update kubeconfig and deploy to EKS
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: openmeet-ecr/openmeet-platform
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          aws eks update-kubeconfig --name openmeet-prod --region ${{ vars.AWS_REGION || 'us-east-1' }}
-
-          # Apply the patch to the dev environment
-          cd openmeet-infrastructure
-
-          # First ensure namespace exists
-          kubectl apply -f k8s/environments/dev/namespace.yaml --validate=false
-
-          # Update the deployment with the new image
-          kubectl set image deployment/platform platform=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG -n dev
-
-          # Update the infrastructure repository with the new image tag
-          sed -i "s|image: .*openmeet-ecr/openmeet-platform:.*|image: $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG|" k8s/environments/dev/kustomization.yaml
-
-          # Configure Git
-          git config --global user.email "github-actions@github.com"
-          git config --global user.name "GitHub Actions"
-
-          # Commit and push the changes
-          git add k8s/environments/dev/kustomization.yaml
-          git commit -m "Update Platform image to $IMAGE_TAG from main branch"
-          git push origin main
-
-          # Wait for rollout to complete
-          kubectl rollout status deployment/platform -n dev
+  gitops-update:
+    needs: [build-and-deploy]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/update-image-gitops.yml
+    with:
+      service_name: platform
+      image_tag: ${{ needs.build-and-deploy.outputs.image_tag }}
+      environment: dev
+      ecr_registry: 433321780850.dkr.ecr.us-east-1.amazonaws.com
+      ecr_repository: openmeet-ecr/openmeet-platform
+      commit_message: "GitOps: Update Platform to ${{ needs.build-and-deploy.outputs.image_tag }} from main branch"
+    secrets:
+      GH_PAT: ${{ secrets.GH_PAT_INFRASTRUCTURE }}

--- a/.github/workflows/update-image-gitops.yml
+++ b/.github/workflows/update-image-gitops.yml
@@ -1,0 +1,111 @@
+name: Update Image Tag (GitOps)
+
+on:
+  workflow_call:
+    inputs:
+      service_name:
+        description: 'Service name (api, platform, biz, etc.)'
+        required: true
+        type: string
+      image_tag:
+        description: 'Docker image tag to deploy'
+        required: true
+        type: string
+      environment:
+        description: 'Target environment (dev, prod, pr-123, etc.)'
+        required: true
+        type: string
+      ecr_registry:
+        description: 'ECR registry URL'
+        required: true
+        type: string
+      ecr_repository:
+        description: 'ECR repository name'
+        required: true
+        type: string
+      commit_message:
+        description: 'Git commit message'
+        required: false
+        type: string
+        default: 'Update image tag'
+    secrets:
+      GH_PAT:
+        description: 'GitHub PAT with repo access'
+        required: true
+
+jobs:
+  update-gitops:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout infrastructure repo
+        uses: actions/checkout@v4
+        with:
+          repository: OpenMeet-Team/openmeet-infrastructure
+          token: ${{ secrets.GH_PAT }}
+          ref: main
+
+      - name: Update kustomization.yaml with new image tag
+        run: |
+          KUSTOMIZATION_PATH="k8s/environments/${{ inputs.environment }}/kustomization.yaml"
+          IMAGE_FULL="${{ inputs.ecr_registry }}/${{ inputs.ecr_repository }}:${{ inputs.image_tag }}"
+
+          echo "Updating $KUSTOMIZATION_PATH"
+          echo "Service: ${{ inputs.service_name }}"
+          echo "New image: $IMAGE_FULL"
+
+          # Update the image tag in the kustomization file
+          # This uses sed to find the line with the service image and update it
+          sed -i "s|image: .*${{ inputs.ecr_repository }}:.*|image: $IMAGE_FULL|" "$KUSTOMIZATION_PATH"
+
+          # Show the diff
+          git diff "$KUSTOMIZATION_PATH"
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions Bot"
+
+          KUSTOMIZATION_PATH="k8s/environments/${{ inputs.environment }}/kustomization.yaml"
+
+          git add "$KUSTOMIZATION_PATH"
+
+          # Check if there are changes to commit
+          if git diff --staged --quiet; then
+            echo "No changes to commit - image tag may already be up to date"
+            exit 0
+          fi
+
+          git commit -m "${{ inputs.commit_message }}"
+
+          # Push with retry logic to handle concurrent updates
+          MAX_RETRIES=5
+          RETRY_COUNT=0
+
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            echo "Attempting to push (attempt $((RETRY_COUNT + 1))/$MAX_RETRIES)..."
+
+            if git push origin main; then
+              echo "✅ Successfully pushed changes"
+              exit 0
+            else
+              echo "⚠️  Push failed, pulling and retrying..."
+              RETRY_COUNT=$((RETRY_COUNT + 1))
+
+              if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                # Pull with rebase to get latest changes
+                git pull --rebase origin main
+                sleep $((RETRY_COUNT * 2))  # Exponential backoff
+              fi
+            fi
+          done
+
+          echo "❌ Failed to push after $MAX_RETRIES attempts"
+          exit 1
+
+      - name: Trigger ArgoCD sync (optional)
+        if: inputs.environment == 'dev'
+        continue-on-error: true
+        run: |
+          echo "ArgoCD will auto-detect the change within 3 minutes"
+          echo "Or manually sync via UI: https://argocd-dev.openmeet.net"
+          # Future: Could add argocd CLI to trigger immediate sync


### PR DESCRIPTION
## Summary
- Implement GitOps workflow for dev environment deployments
- PRs now only run tests (linting)
- Main branch builds, pushes to ECR, and updates via GitOps
- ArgoCD automatically syncs infrastructure repo changes to cluster
- Eliminates kubectl commands and race conditions
- Git becomes single source of truth for deployments

## Changes
1. Added reusable `update-image-gitops.yml` workflow (same as API repo)
2. Updated `deploy-to-dev.yml`:
   - PRs: Run linting only (no deployment to shared dev)
   - Main: Build image, push to ECR, update infrastructure repo via GitOps
   - Removed all kubectl commands
   - Removed infrastructure repo checkout from main workflow

## Test Plan
- PR will run linting tests
- After merge to main, workflow will build and deploy via GitOps
- ArgoCD will sync changes automatically

## Related
Addresses OpenMeet-Team/openmeet-infrastructure#4 (Phase 1)
Following same pattern as openmeet-api PR #326