### PR TITLE
fix: remove try_files from if block

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -66,17 +66,15 @@ server {
         proxy_set_header User-Agent $http_user_agent;
         proxy_set_header X-Tenant-Id ${APP_TENANT_ID};  # Pass platform's tenant ID to API
 
-        # If bot: proxy to API for meta tags
+        # If bot: proxy to API for meta tags (proxy_pass stops processing)
         if ($is_bot) {
             # Rewrite to /api/meta prefix (API has global /api prefix)
             rewrite ^(.*)$ /api/meta$1 break;
             proxy_pass ${BACKEND_DOMAIN};
         }
 
-        # Humans: serve SPA (Vue Router handles the route)
-        if ($is_bot = 0) {
-            try_files $uri /index.html;
-        }
+        # Default for humans: serve SPA (Vue Router handles the route)
+        try_files $uri /index.html;
     }
 
     # --- Static Assets ---


### PR DESCRIPTION
## Issue
Platform container fails to start with nginx error:
```
nginx: [emerg] "try_files" directive is not allowed here in /etc/nginx/conf.d/default.conf:78
```

## Root Cause
Nginx has strict rules about what directives can be inside `if` blocks. `try_files` is not allowed inside `if` blocks.

## Fix
Removed the `if ($is_bot = 0)` block entirely. The logic works correctly without it:
- When `if ($is_bot)` triggers, `proxy_pass` stops request processing (proxies to API)
- When `if ($is_bot)` doesn't trigger, nginx continues to the next directive (`try_files`)

This is the standard nginx pattern for conditional proxying.

## Testing
- Platform container should start successfully
- Bot requests should get proxied to API meta endpoint
- Human requests should serve the SPA via try_files