### PR TITLE
fix: remove overly broad nginx bot detection patterns

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -117,7 +117,6 @@ map $http_user_agent $is_bot {
 
     # Apple
     ~*applebot 1;
-    ~*apple 1;
 
     # Other Search Engines
     ~*seznambot 1;
@@ -194,7 +193,7 @@ map $http_user_agent $is_bot {
     # ============================================================
 
     ~*archive\.org 1;
-    ~*archive 1;
+    ~*ia_archiver 1;
     ~*wayback 1;
     ~*httrack 1;
     ~*wget 1;


### PR DESCRIPTION
## Problem

PR #272 introduced overly broad bot detection patterns that caught normal Chrome and Edge browsers, causing redirect loops on event pages.

### Root Cause
The pattern `~*apple 1` matches `AppleWebKit` which is present in **all** Chrome and Edge user agent strings:
- Chrome: `Mozilla/5.0 ... AppleWebKit/537.36 ... Chrome/120.0.0.0`
- Edge: `Mozilla/5.0 ... AppleWebKit/537.36 ... Edg/120.0.0.0`

This caused these browsers to be incorrectly treated as bots and routed to the API meta endpoint, creating a redirect loop.

## Changes

✅ **Remove `~*apple 1` pattern** (line 120)
- Keeps `~*applebot 1` for the actual Apple web crawler
- Prevents Chrome/Edge from being misidentified as bots

✅ **Replace `~*archive 1` with `~*ia_archiver 1`** (line 196)
- More specific pattern for Internet Archive crawler
- Prevents false positives from generic "archive" strings

✅ **Keep social media patterns** (`~*facebook`, `~*twitter`)
- These are less likely to appear in normal browser user agents
- Necessary for social media link preview crawlers

## Testing

- ✅ Nginx configuration syntax validated
- ✅ Chrome user agents no longer match bot patterns
- ✅ Edge user agents no longer match bot patterns
- ✅ Actual bot crawlers (applebot, ia_archiver) still detected

## Impact

- **Fixes**: Chrome/Edge redirect loop on event pages (reported by Vlad in Discord)
- **Fixes**: "Event not found" errors in Chrome/Edge
- **Fixes**: WhatsApp link preview issues (related to same redirect problem)
- **No impact**: Bot detection for actual crawlers remains comprehensive

## Related

- Fixes bug introduced in #272
- Related to #259 (per-event link preview metadata)
- Discord bug report: redirect loop affecting Chrome/Edge users

## Deployment Notes

- Should be deployed ASAP to fix production redirect loops
- No breaking changes
- Safe to deploy independently