### PR TITLE
Fix: Increase nginx URL buffer for Bluesky OAuth

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -215,6 +215,11 @@ server {
     listen 80;
     server_name _;
 
+    # Increase buffer size for long URLs (Bluesky OAuth callback with JWT tokens)
+    # Default: 4 8k (32KB total)
+    # New: 4 32k (128KB total) - handles OAuth callbacks with full user data
+    large_client_header_buffers 4 32k;
+
     # Root directory for static files
     root /usr/share/nginx/html;
 


### PR DESCRIPTION
## Problem

Bluesky OAuth callback URLs exceed nginx's 32KB limit, causing 414 errors.
URLs contain JWT tokens + full user object (~20-30KB in query params).

## Solution

Increase `large_client_header_buffers` from 32KB → 128KB.

## Note

Temporary fix. Long-term: store auth data server-side, pass short token only.