### PR TITLE
Fix: Clear activity log when navigating between events (#273)

### DIFF
--- a/src/components/event/EventActivityFeedComponent.vue
+++ b/src/components/event/EventActivityFeedComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { activityFeedApi } from '../../api/activity-feed'
 import { ActivityFeedEntity } from '../../types'
 import { formatRelativeTime } from '../../utils/dateUtils'
@@ -28,6 +28,13 @@ const hasMore = ref(true)
 const limit = 10
 
 onMounted(async () => {
+  await fetchActivities()
+})
+
+watch(() => props.eventSlug, async () => {
+  activities.value = []
+  hasMore.value = true
+  error.value = null
   await fetchActivities()
 })
 


### PR DESCRIPTION
## Summary
Fixes #273 - Activity log now properly clears when navigating between events via the "similar events" section.

## Changes
- Added `watch` on `eventSlug` prop in `EventActivityFeedComponent.vue`
- Clears activities array, error state, and pagination flags before fetching new data
- Ensures fresh activity data is displayed for each event

## Test Plan
- Navigate to an event with activity
- Click on a similar event
- Verify the activity log updates to show the new event's activity (not the previous event's)

## Technical Details
The component previously only fetched activities in `onMounted`. When navigating between events, Vue Router reuses component instances, so `onMounted` wasn't called again and stale data persisted. The watcher now triggers a fresh fetch whenever the event slug changes.