### PR TITLE
Fix: Improve Matrix chat link readability (#283)

### DIFF
--- a/src/components/chat/EventTile.vue
+++ b/src/components/chat/EventTile.vue
@@ -521,4 +521,20 @@ const getSenderColor = (userId: string): string => {
     background: rgba(255, 193, 7, 0.2);
   }
 }
+
+/* Link Styling - Issue #283 */
+/* Fix link visibility in own messages (blue background needs contrast) */
+/* Use white with underline for clean readability */
+.own-message-body :deep(a) {
+  color: #FFFFFF !important; /* White for maximum readability */
+  text-decoration: underline !important;
+  text-decoration-color: #60CBA4 !important; /* $green underline */
+  text-decoration-thickness: 2px !important;
+}
+
+.own-message-body :deep(a:hover) {
+  color: #EEEDFB !important; /* $purple-100 on hover */
+  text-decoration-color: #FFB677 !important; /* $orange underline on hover */
+  text-decoration-thickness: 2px !important;
+}
 </style>

--- a/src/components/chat/MessageBody.vue
+++ b/src/components/chat/MessageBody.vue
@@ -940,19 +940,28 @@ body.body--dark {
   }
 }
 
-/* Links in messages */
+/* Links in messages - Issue #283 */
+/* Default link styling for messages from others (gray background) */
 :deep(a) {
-  color: #1976d2;
-  text-decoration: none;
+  color: #1E1A43; /* $purple-600 - darkest purple for strong contrast on gray */
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  font-weight: 500;
 }
 
 :deep(a:hover) {
-  text-decoration: underline;
+  color: #4238A6; /* $purple-500 on hover */
+  text-decoration-thickness: 2px;
 }
 
 @media (prefers-color-scheme: dark) {
   :deep(a) {
-    color: #64b5f6;
+    color: #22B2DA; /* $blue for better contrast in dark mode */
+    font-weight: 600;
+  }
+
+  :deep(a:hover) {
+    color: #60CBA4; /* $green on hover */
   }
 }
 </style>


### PR DESCRIPTION
## Summary
Fixes #283 - Links are now readable in Matrix chat on both blue and gray backgrounds.

## Changes
- Own messages (blue bg): White text with green underline
- Other messages (gray bg): Dark purple for contrast
- Dark mode: Blue links with better visibility
- Added hover states using brand colors

## Test Plan
- Links readable on all backgrounds (blue, gray, dark mode)
- Hover states work correctly

Functional fix - designer may refine styling later.