### PR TITLE
feat(chat): Hide Matrix membership status messages

### DIFF
--- a/src/components/chat/EventTile.vue
+++ b/src/components/chat/EventTile.vue
@@ -289,8 +289,9 @@ const shouldDisplayEvent = computed(() => {
     return true
   }
 
-  // Display message events, state events we care about, and encrypted events
-  return isMessageEvent.value || isStateEvent.value || isEncryptedEvent.value
+  // Display message events and encrypted events only
+  // State events (joins, leaves, etc.) are now hidden for cleaner chat UX
+  return isMessageEvent.value || isEncryptedEvent.value
 })
 
 // State event text generation


### PR DESCRIPTION
## Summary

Hides join/leave/invite system messages in Matrix chat for cleaner UX.

**Changes:**
- Grey status messages (joined/left/invited) no longer displayed
- Only actual chat messages shown
- State events still tracked internally, just not rendered

## Before

Chat showing:
```
Alice joined the room
Bob joined the room
Alice: Hello!
Charlie left the room
Bob: Hi there
```

## After

Chat showing:
```
Alice: Hello!
Bob: Hi there
```

## Testing

- [x] Linting passes
- [ ] Manual test: Join/leave a chat room → status messages not shown
- [ ] Manual test: Regular messages still display correctly

---

Related: #249