### PR TITLE
fix: Update user-facing copy from 'Bluesky' to 'AT Protocol'

### DIFF
--- a/src/components/auth/BlueSkyLoginComponent.vue
+++ b/src/components/auth/BlueSkyLoginComponent.vue
@@ -48,10 +48,10 @@ const $q = useQuasar()
 
 const buttonText = computed(() => {
   const textMap = {
-    join_with: 'Join with Bluesky',
-    signin_with: 'Sign in with Bluesky',
-    signup_with: 'Sign up with Bluesky',
-    continue_with: 'Continue with Bluesky'
+    join_with: 'Join with AT Protocol',
+    signin_with: 'Sign in with AT Protocol',
+    signup_with: 'Sign in with AT Protocol',
+    continue_with: 'Continue with AT Protocol'
   }
   return textMap[props.text]
 })
@@ -62,8 +62,8 @@ const handleBlueskyLogin = async () => {
 
     // Open a dialog to get the Bluesky handle
     $q.dialog({
-      title: 'Enter your Bluesky handle',
-      message: 'Please enter your Bluesky handle (e.g., alice.bsky.social)',
+      title: 'Enter your AT Protocol handle',
+      message: 'Please enter your AT Protocol handle (e.g., alice.bsky.social)',
       prompt: {
         model: '',
         type: 'text'
@@ -109,7 +109,7 @@ const handleBlueskyLogin = async () => {
     console.error('Bluesky auth error:', error)
     $q.notify({
       type: 'negative',
-      message: 'Bluesky authentication failed'
+      message: 'AT Protocol authentication failed'
     })
     isLoading.value = false
   }

--- a/src/components/dashboard/DashboardProfileForm.vue
+++ b/src/components/dashboard/DashboardProfileForm.vue
@@ -141,7 +141,7 @@
         <q-card-section>
           <div class="text-h6 q-mb-md">
             <q-icon name="sym_r_cloud" class="q-mr-sm" />
-            Bluesky Settings
+            AT Protocol Settings
           </div>
           <div class="q-gutter-y-md">
             <div class="text-subtitle2" v-if="form.preferences?.bluesky?.handle">
@@ -156,7 +156,7 @@
 
             <q-toggle
               v-model="form.preferences.bluesky.connected"
-              label="Use Bluesky as event source"
+              label="Use AT Protocol as event source"
               @update:model-value="onBlueskyConnectionToggle"
             />
           </div>

--- a/src/components/event/EventFormBasicComponent.vue
+++ b/src/components/event/EventFormBasicComponent.vue
@@ -264,7 +264,7 @@
               data-cy="event-publish-to-bluesky"
               v-model="publishToBluesky"
               :disable="!!eventData.slug"
-              label="Publish to Bluesky"
+              label="Publish to AT Protocol"
             />
             <p class="text-caption q-mt-xs q-ml-md text-warning" v-if="!eventData.slug">
               <q-icon name="sym_r_warning" size="xs" />

--- a/src/pages/MemberPage.vue
+++ b/src/pages/MemberPage.vue
@@ -196,7 +196,7 @@ const loadBlueskyEvents = async () => {
             <q-card-section>
               <div class="text-center">
                 <q-icon name="fa-brands fa-bluesky" color="primary" size="2rem" />
-                <h6 class="q-mt-sm q-mb-none">Bluesky User</h6>
+                <h6 class="q-mt-sm q-mb-none">AT Protocol User</h6>
                 <div class="text-body2 q-mt-sm" v-if="bskyHandle">
                   <a
                     :href="`https://bsky.app/profile/${bskyHandle}`"
@@ -211,7 +211,7 @@ const loadBlueskyEvents = async () => {
 
             <!-- Add Bluesky Events Section (only shown if this is the user's own profile) -->
             <q-card-section v-if="blueskyEvents?.length > 0 && isOwnProfile">
-              <div class="text-h6 q-mb-md">Events on Bluesky</div>
+              <div class="text-h6 q-mb-md">AT Protocol Events</div>
               <div class="q-gutter-y-md">
                 <q-card flat bordered v-for="event in blueskyEvents" :key="event.uri" class="event-card">
                   <q-card-section>


### PR DESCRIPTION
## Summary

Updates all user-facing text to refer to 'AT Protocol' instead of 'Bluesky'. Internal code entities (like `sourceType === 'bluesky'`, variable names, etc.) remain unchanged and will be addressed in a future tech debt issue.

## Changes

### MemberPage.vue
- 'Events on Bluesky' → 'AT Protocol Events'
- 'Bluesky User' → 'AT Protocol User'

### BlueSkyLoginComponent.vue
- All auth button text: 'Join/Sign in/Sign up/Continue with Bluesky' → '...with AT Protocol'
- Dialog title/message: 'Enter your Bluesky handle' → 'Enter your AT Protocol handle'
- Error message: 'Bluesky authentication failed' → 'AT Protocol authentication failed'

### DashboardProfileForm.vue
- 'Bluesky Settings' → 'AT Protocol Settings'
- 'Use Bluesky as event source' → 'Use AT Protocol as event source'

### EventFormBasicComponent.vue
- 'Publish to Bluesky' → 'Publish to AT Protocol'

## What's NOT Changed

- Share buttons to bsky.app social network intentionally kept as 'Bluesky'
- Internal code: `sourceType`, variable names, comments (will address in tech debt)

Fixes #278