### PR TITLE
fix: Show attendees for authenticated events without login requirement

### DIFF
--- a/src/components/event/EventAttendeesComponent.vue
+++ b/src/components/event/EventAttendeesComponent.vue
@@ -52,7 +52,10 @@ const router = useRouter()
 const { getUserIdentifier } = useUserIdentifier()
 
 const onAttendeesClick = () => {
-  if (!useAuthStore().isAuthenticated) {
+  // Allow viewing attendees for public and authenticated events without login
+  if (useEventStore().getterIsPublicEvent || useEventStore().getterIsAuthenticatedEvent) {
+    router.push({ name: 'EventAttendeesPage', params: { slug: route.params.slug } })
+  } else if (!useAuthStore().isAuthenticated) {
     goToLogin()
   } else if (!useEventStore().getterUserHasPermission(EventAttendeePermission.ViewEvent)) {
     openNoAttendeesRightsDialog()
@@ -62,6 +65,6 @@ const onAttendeesClick = () => {
 }
 
 const hasPermissions = computed(() => {
-  return (useEventStore().getterIsPublicEvent || (useEventStore().getterIsAuthenticatedEvent && useAuthStore().isAuthenticated) || (useEventStore().getterUserIsAttendee() && useEventStore().getterUserHasPermission(EventAttendeePermission.ViewEvent)))
+  return (useEventStore().getterIsPublicEvent || useEventStore().getterIsAuthenticatedEvent || (useEventStore().getterUserIsAttendee() && useEventStore().getterUserHasPermission(EventAttendeePermission.ViewEvent)))
 })
 </script>

--- a/src/pages/event/EventAttendeesPage.vue
+++ b/src/pages/event/EventAttendeesPage.vue
@@ -125,7 +125,6 @@ import { useEventStore } from '../../stores/event-store'
 import { eventsApi } from '../../api'
 import { EventAttendeeEntity, EventAttendeePermission, EventAttendeeStatus } from '../../types'
 import { getImageSrc } from '../../utils/imageUtils'
-import { useAuthStore } from '../../stores/auth-store'
 import SpinnerComponent from '../../components/common/SpinnerComponent.vue'
 import NoContentComponent from '../../components/global/NoContentComponent.vue'
 import MenuItemComponent from '../../components/common/MenuItemComponent.vue'
@@ -268,7 +267,7 @@ onMounted(() => {
   LoadingBar.start()
   isLoading.value = true
   useEventStore().actionGetEventBySlug(route.params.slug as string).then(() => {
-    if (useEventStore().getterIsPublicEvent || (useEventStore().getterIsAuthenticatedEvent && useAuthStore().isAuthenticated) || useEventStore().getterUserIsAttendee()) {
+    if (useEventStore().getterIsPublicEvent || useEventStore().getterIsAuthenticatedEvent || useEventStore().getterUserIsAttendee()) {
       loadAttendees().finally(() => {
         LoadingBar.stop()
         isMounted.value = true


### PR DESCRIPTION
## Summary

Removes authentication requirement for viewing attendees on authenticated (unlisted) events. This fixes an inconsistency where the activity feed displays attendee information but the attendees list requires login.

## Problem

Currently, for authenticated (unlisted) events:
- ❌ Attendees list is hidden with "You don't have permission to view this"
- ✅ Activity feed shows "Alice is attending Event X"

This is inconsistent - the activity feed already reveals who's attending, making the attendees restriction pointless.

## Solution

Remove login requirement for viewing attendees on authenticated events, aligning with the "unlisted but transparent" philosophy.

## Event Visibility Comparison

| Feature | Public | Authenticated (Unlisted) | Private |
|---------|--------|-------------------------|---------|
| **Search Index** | ✅ Searchable | ❌ Not indexed | ❌ Not indexed |
| **Link Preview** | ✅ Yes | ✅ Yes | ❌ No (404) |
| **Bot Access** | ✅ Full | ✅ Preview only | ❌ Blocked |
| **Attendees Visible** | ✅ Everyone | ✅ Everyone with link | ❌ Attendees only |
| **Activity Feed Visible** | ✅ Everyone | ✅ Everyone with link | ❌ Attendees only |

## Philosophy

**Public:** Fully discoverable and open
**Authenticated (Unlisted):** Not searchable, but transparent if you have the link
**Private:** Truly private - attendees only

Fixes #279