### PR TITLE
fix: Display actual error messages for event access control (Issue #379)

### DIFF
--- a/src/pages/EventPage.vue
+++ b/src/pages/EventPage.vue
@@ -873,7 +873,7 @@
     <NoContentComponent
       data-cy="event-not-found"
       v-if="errorMessage"
-      label="Event not found"
+      :label="errorMessage"
       icon="sym_r_error"
       @click="router.push({ name: 'EventsPage' })"
       button-label="Go to events"


### PR DESCRIPTION
## Summary
Fixes EventPage to display dynamic error messages instead of always showing "Event not found".

## Problem
When accessing restricted events, users always saw "Event not found" regardless of the actual error (403, 404, 500, network error).

## Solution
Changed `EventPage.vue` line 876 from hardcoded `label="Event not found"` to dynamic `:label="errorMessage"`.

## Result
Users now see specific feedback:
- **403:** "Access denied. You may not have permission to view this event."
- **404:** "Event not found."
- **500:** "Server error. Please try again later."
- **Network:** "Network error. Please check your internet connection."

## Related
Complements backend security fix in openmeet-api #379 which added VisibilityGuard to activity feed endpoints.