### PR TITLE
feat: rename Authenticated → Unlisted visibility for events and groups

### DIFF
--- a/src/components/event/EventFormBasicComponent.vue
+++ b/src/components/event/EventFormBasicComponent.vue
@@ -300,13 +300,13 @@
               filled
             />
             <p class="text-caption q-mt-sm" v-if="eventData.visibility === EventVisibility.Private">
-              If private, the event is hidden from search and accessible only by direct link or group members.
+              Private events are hidden from search and accessible only by direct link or group members.
             </p>
             <p class="text-caption q-mt-sm" v-if="eventData.visibility === EventVisibility.Public">
-              If public, the event is visible to everyone and searchable.
+              Public events are visible to everyone and appear in search results.
             </p>
-            <p class="text-caption q-mt-sm" v-if="eventData.visibility === EventVisibility.Authenticated">
-              If authenticated, the event is visible to authenticated users and searchable.
+            <p class="text-caption q-mt-sm" v-if="eventData.visibility === EventVisibility.Unlisted">
+              Unlisted events are hidden from search but anyone with the link can view them.
             </p>
             <p class="text-caption q-mt-sm text-warning" v-if="publishToBluesky && eventData.visibility !== EventVisibility.Public">
               <q-icon name="sym_r_warning" size="xs" />
@@ -412,7 +412,7 @@ const publishToBluesky = ref<boolean>(false)
 const visibilityOptions = computed(() => {
   const baseOptions = [
     { label: 'The World', value: 'public', disable: false },
-    { label: 'Authenticated Users', value: 'authenticated', disable: publishToBluesky.value },
+    { label: 'Anyone with Link', value: 'unlisted', disable: publishToBluesky.value },
     { label: 'People You Invite', value: 'private', disable: publishToBluesky.value }
   ]
   return baseOptions

--- a/src/components/group/GroupFormComponent.vue
+++ b/src/components/group/GroupFormComponent.vue
@@ -109,17 +109,17 @@
           <q-select data-cy="group-visibility" v-model="group.visibility" label="Group Viewable By" option-value="value"
             option-label="label" emit-value map-options :options="[
               { label: 'The World', value: 'public' },
-              { label: 'Authenticated Users', value: 'authenticated' },
+              { label: 'Anyone with Link', value: 'unlisted' },
               { label: 'Private Group', value: 'private' }
             ]" filled />
           <p class="text-caption q-mt-sm" v-if="group.visibility === GroupVisibility.Private">
-            Only invited members can view and join this group. Not found in search and membership available only with group invite.
+            Private groups are hidden from search and only invited members can view and join.
           </p>
-          <p class="text-caption q-mt-sm" v-if="group.visibility === GroupVisibility.Authenticated">
-            Only logged-in users can view and join. Found in search for authenticated users.
+          <p class="text-caption q-mt-sm" v-if="group.visibility === GroupVisibility.Unlisted">
+            Unlisted groups are hidden from search but anyone with the link can view and join.
           </p>
           <p class="text-caption q-mt-sm" v-if="group.visibility === GroupVisibility.Public">
-            Anyone can view and join this group. Found in search.
+            Public groups are visible to everyone and appear in search results.
           </p>
         </div>
 

--- a/src/stores/event-store.ts
+++ b/src/stores/event-store.ts
@@ -35,7 +35,7 @@ export const useEventStore = defineStore('event', {
       return state.event?.visibility === EventVisibility.Private
     },
     getterIsAuthenticatedEvent: (state) => {
-      return state.event?.visibility === EventVisibility.Authenticated
+      return state.event?.visibility === EventVisibility.Unlisted
     }
   },
 

--- a/src/stores/group-store.ts
+++ b/src/stores/group-store.ts
@@ -33,7 +33,7 @@ export const useGroupStore = defineStore('group', {
       return state.group?.visibility === GroupVisibility.Private
     },
     getterIsAuthenticatedGroup: (state) => {
-      return state.group?.visibility === GroupVisibility.Authenticated
+      return state.group?.visibility === GroupVisibility.Unlisted
     },
     getterIsPermissionError: (state) => {
       return state.errorCode === 403

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -30,7 +30,7 @@ export enum EventAttendeePermission {
 
 export enum EventVisibility {
   Public = 'public',
-  Authenticated = 'authenticated',
+  Unlisted = 'unlisted',
   Private = 'private'
 }
 

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -3,10 +3,10 @@ import { MatrixMessage } from './matrix'
 import { UserEntity } from './user'
 import { EventEntity } from './event'
 
-export type GroupVisibilityType = 'public' | 'authenticated' | 'private'
+export type GroupVisibilityType = 'public' | 'unlisted' | 'private'
 export enum GroupVisibility {
   Public = 'public',
-  Authenticated = 'authenticated',
+  Unlisted = 'unlisted',
   Private = 'private'
 }
 

--- a/test/cypress/e2e/event.cy.ts
+++ b/test/cypress/e2e/event.cy.ts
@@ -69,7 +69,7 @@ describe('EventPage', () => {
         statusCode: 200,
         body: {
           ...event,
-          visibility: EventVisibility.Authenticated
+          visibility: EventVisibility.Unlisted
         } as EventEntity
       }).as('getEvent')
 

--- a/test/cypress/e2e/group.cy.ts
+++ b/test/cypress/e2e/group.cy.ts
@@ -159,7 +159,7 @@ describe('GroupPage', () => {
         statusCode: 200,
         body: {
           ...group,
-          visibility: GroupVisibility.Authenticated
+          visibility: GroupVisibility.Unlisted
         } as GroupEntity
       }).as('getGroup')
 


### PR DESCRIPTION
## Summary
Renames "Authenticated" visibility to "Unlisted" to match industry standards (YouTube, GitHub, Google Docs).

This is a **BREAKING CHANGE** affecting the frontend types and UI.

## Changes

### Type Updates
- Updated `EventVisibility` enum in `src/types/event.ts`
- Updated `GroupVisibility` enum and type alias in `src/types/group.ts`
- Changed `'authenticated'` → `'unlisted'` across all type definitions

### UI Updates
- **EventFormBasicComponent.vue**: Label changed from "Authenticated Users" → "Anyone with Link"
- **GroupFormComponent.vue**: Label changed from "Authenticated Users" → "Anyone with Link"
- Updated descriptions to clarify unlisted behavior:
  - Events: "Unlisted events are hidden from search but anyone with the link can view them."
  - Groups: "Unlisted groups are hidden from search but anyone with the link can view and join."

### Test Updates
- Fixed Cypress E2E tests to use `EventVisibility.Unlisted` and `GroupVisibility.Unlisted`
- Updated test descriptions to use "unlisted" terminology

## Related
- Part of P0 Security Fixes for Access & Attendance MVP
- Companion PR in openmeet-api: OpenMeet-Team/openmeet-api#385

## Deployment Notes
- Must be deployed in sync with backend PR #385
- Frontend and backend must be updated together to avoid type mismatches