### PR TITLE
fix: resolve join button race condition in group store

### DIFF
--- a/src/stores/group-store.ts
+++ b/src/stores/group-store.ts
@@ -105,14 +105,11 @@ export const useGroupStore = defineStore('group', {
         const res = await groupsApi.join(slug)
         if (this.group) {
           if (res.data.groupRole.name !== GroupRole.Guest) {
-            if (this.group.groupMembers?.find(m => m.id === res.data.id)) {
+            if (!this.group.groupMembers?.find(m => m.id === res.data.id)) {
               this.group.groupMembers = this.group.groupMembers ? [...this.group.groupMembers, res.data] : [res.data]
             }
           }
           this.group.groupMember = res.data
-
-          // Refresh group data to ensure we have the latest permissions and state
-          await this.actionGetGroup(slug)
         }
         analyticsService.trackEvent('group_joined', { group_id: this.group?.id, name: this.group?.name })
       } catch (err) {


### PR DESCRIPTION
## Summary
Fixes the issue where users had to click "Join this group" button twice for unlisted groups.

This PR resolves two bugs in the `actionJoinGroup` method:
- **Inverted logic** at line 108 that prevented new members from being added to the `groupMembers` array
- **Race condition** caused by refreshing group data immediately after join, which overwrote the correct membership state with stale API data

## Changes
- Fixed conditional logic to add members who are NOT already in the list (added `!` operator)
- Removed `actionGetGroup` refresh call that was causing race condition
- Join button now updates immediately after first click

## Test plan
- [x] Navigate to an unlisted group while logged in
- [x] Click "Join this group" button
- [x] Verify button updates to "Leave" or appropriate state after single click
- [x] Verify no second click is required
- [x] Test with public and private groups to ensure no regression

**Tested locally and confirmed working.**