### PR TITLE
Disable Private visibility option in UI for MVP

### DIFF
--- a/src/components/event/EventFormBasicComponent.vue
+++ b/src/components/event/EventFormBasicComponent.vue
@@ -308,6 +308,10 @@
             <p class="text-caption q-mt-sm" v-if="eventData.visibility === EventVisibility.Unlisted">
               Unlisted events are hidden from search but anyone with the link can view them.
             </p>
+            <p class="text-caption q-mt-sm text-info">
+              <q-icon name="sym_r_info" size="xs" />
+              Private events with invitations launching soon. Use "Anyone with Link" for now.
+            </p>
             <p class="text-caption q-mt-sm text-warning" v-if="publishToBluesky && eventData.visibility !== EventVisibility.Public">
               <q-icon name="sym_r_warning" size="xs" />
               This event will only be created on OpenMeet (not published to Bluesky) because it is not public.
@@ -413,7 +417,7 @@ const visibilityOptions = computed(() => {
   const baseOptions = [
     { label: 'The World', value: 'public', disable: false },
     { label: 'Anyone with Link', value: 'unlisted', disable: publishToBluesky.value },
-    { label: 'People You Invite', value: 'private', disable: publishToBluesky.value }
+    { label: 'People You Invite - Coming soon!', value: 'private', disable: true }
   ]
   return baseOptions
 })

--- a/src/components/group/GroupFormComponent.vue
+++ b/src/components/group/GroupFormComponent.vue
@@ -108,9 +108,9 @@
           <div class="text-subtitle2 q-mb-sm">Visibility</div>
           <q-select data-cy="group-visibility" v-model="group.visibility" label="Group Viewable By" option-value="value"
             option-label="label" emit-value map-options :options="[
-              { label: 'The World', value: 'public' },
-              { label: 'Anyone with Link', value: 'unlisted' },
-              { label: 'Private Group', value: 'private' }
+              { label: 'The World', value: 'public', disable: false },
+              { label: 'Anyone with Link', value: 'unlisted', disable: false },
+              { label: 'Private Group - Coming soon!', value: 'private', disable: true }
             ]" filled />
           <p class="text-caption q-mt-sm" v-if="group.visibility === GroupVisibility.Private">
             Private groups are hidden from search and only invited members can view and join.
@@ -120,6 +120,10 @@
           </p>
           <p class="text-caption q-mt-sm" v-if="group.visibility === GroupVisibility.Public">
             Public groups are visible to everyone and appear in search results.
+          </p>
+          <p class="text-caption q-mt-sm text-info">
+            <q-icon name="sym_r_info" size="xs" />
+            Private groups with invitations launching soon. Use "Anyone with Link" for now.
           </p>
         </div>
 
@@ -163,7 +167,7 @@ const group = ref<GroupEntity>({
   location: '',
   requireApproval: true,
   status: GroupStatus.Draft,
-  visibility: GroupVisibility.Private
+  visibility: GroupVisibility.Public
 })
 
 const loading = ref(false)


### PR DESCRIPTION
## Summary
Disables the Private visibility option for both events and groups in the UI as part of the MVP launch strategy. Private visibility will be re-enabled once the invitation system is ready (2-3 weeks post-MVP).

## Changes
- **EventFormBasicComponent.vue**: 
  - Set Private option to `disable: true`
  - Updated label to "People You Invite - Coming soon!"
  - Added info message: "Private events with invitations launching soon. Use 'Anyone with Link' for now."

- **GroupFormComponent.vue**:
  - Set Private option to `disable: true`
  - Updated label to "Private Group - Coming soon!"
  - Changed default visibility from Private to Public for new groups
  - Added info message: "Private groups with invitations launching soon. Use 'Anyone with Link' for now."

## MVP Strategy
**What's Shipping:**
✅ Public visibility - fully working
✅ Unlisted visibility - fully working  
❌ Private visibility - disabled with "Coming soon" message

**Why:**
- Private events/groups need invitation system to be useful
- Private groups have NO way to add members (critical blocker)
- Unlisted covers 80% of "private" use cases (birthday parties, game nights, etc.)

**Backend:**
- Backend still fully supports Private visibility
- Existing private entities can still be viewed/managed
- Only UI prevents creating new Private events/groups

## Post-MVP
Private visibility will be re-enabled after implementing:
1. Direct user invitations (2-3 weeks, tracked in API issue #393)
2. Email invitations (1-2 months)
3. Viral invitation chains (2-3 months)

## Testing
- [x] TypeScript compilation passes (no new errors in modified files)
- [x] Manual testing: Private option is grayed out in event/group forms
- [x] Manual testing: Info message displays correctly
- [x] Manual testing: Can still create Public and Unlisted events/groups

## Related
- Design doc: `design-notes/PROPOSED-MVP-ISSUES.md`
- Post-MVP capacity enforcement: openmeet-api#393
- Post-MVP remove notification: openmeet-api#394