### PR TITLE
feat: display API error messages in event form notifications

### DIFF
--- a/src/components/event/EventFormBasicComponent.vue
+++ b/src/components/event/EventFormBasicComponent.vue
@@ -757,9 +757,11 @@ const onSubmit = async () => {
       // This is the standard single event path
       await createOrUpdateSingleEvent(event)
     }
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('Failed to create/update event:', err)
-    error('Failed to create event')
+    const axiosError = err as { response?: { data?: { message?: string } } }
+    const errorMessage = axiosError.response?.data?.message || 'Failed to create event'
+    error(errorMessage)
   }
 }
 
@@ -809,9 +811,11 @@ const createOrUpdateSingleEvent = async (event: EventEntity) => {
         source: event.sourceType || 'web'
       })
     }
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('Failed to create/update single event:', err)
-    error('Failed to create/update event')
+    const axiosError = err as { response?: { data?: { message?: string } } }
+    const errorMessage = axiosError.response?.data?.message || 'Failed to create/update event'
+    error(errorMessage)
     throw err
   }
 }


### PR DESCRIPTION
## Summary
- Shows actual API error messages in toast notifications instead of generic "Failed to create/update event" text
- Enables users to see specific validation errors (e.g., capacity enforcement messages from openmeet-api PR #405)

## Related
- Companion to OpenMeet-Team/openmeet-api#405 (capacity enforcement)
- Closes #393

## Test plan
- [x] Try to reduce event capacity below confirmed attendee count
- [x] Verify the specific error message appears in the toast (e.g., "Cannot reduce capacity to 20. Event has 26 confirmed attendees.")
- [ ] Verify other API errors also display their messages