### PR TITLE
feat: display attending events on user profile page

### DIFF
--- a/src/pages/MemberPage.vue
+++ b/src/pages/MemberPage.vue
@@ -26,6 +26,7 @@ const profileUser = computed(() => profileStore.user)
 const interests = computed(() => profileUser.value?.interests || [])
 const ownedGroups = computed(() => profileUser.value?.groups || [])
 const organizedEvents = computed(() => profileUser.value?.events || [])
+const attendingEvents = computed(() => profileUser.value?.attendingEvents || [])
 const groupMemberships = computed(() =>
   profileUser.value?.groupMembers?.filter(
     (member) => member.groupRole?.name !== 'owner'
@@ -367,6 +368,22 @@ const loadBlueskyEvents = async () => {
               />
               <EventsItemComponent
                 v-for="event in organizedEvents"
+                :key="event.id"
+                :event="event"
+              />
+            </q-card-section>
+          </q-card>
+
+          <!-- Attending Events -->
+          <q-card flat bordered class="q-mb-lg" v-if="attendingEvents?.length">
+            <q-card-section>
+              <SubtitleComponent
+                :count="attendingEvents.length"
+                hide-link
+                label="Attending Events"
+              />
+              <EventsItemComponent
+                v-for="event in attendingEvents"
                 :key="event.id"
                 :event="event"
               />

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -74,6 +74,10 @@ export interface Profile {
   interests?: SubCategoryEntity[]
 }
 
+export interface AttendingEvent extends EventEntity {
+  attendeeStatus?: string
+}
+
 export interface UserEntity {
   id: number
   ulid: string
@@ -96,6 +100,7 @@ export interface UserEntity {
   role?: UserRoleEntity
   groups?: GroupEntity[]
   events?: EventEntity[]
+  attendingEvents?: AttendingEvent[]
   groupMembers?: GroupMemberEntity[]
   interests?: SubCategoryEntity[]
   preferences?: UserPreferences


### PR DESCRIPTION
## Summary
- Adds "Attending Events" section to user profile pages
- Shows events the user has RSVPed to (using the new `attendingEvents` field from the API)
- Particularly useful for shadow accounts from Bluesky RSVPs whose profiles would otherwise be empty

## Changes
- `src/types/user.ts`: Added `AttendingEvent` interface and `attendingEvents` field to `UserEntity`
- `src/pages/MemberPage.vue`: Added computed property and template section for attending events

## Dependencies
- Requires the corresponding API change that adds `attendingEvents` to the profile response (openmeet-api branch: `fix/shadow-account-preferences-handle`)

## Test plan
- [ ] View a shadow account profile that has RSVPed to events
- [ ] Verify the "Attending Events" section appears with the correct events
- [ ] Verify regular user profiles still work correctly
- [ ] Verify users with no attending events don't show the section

Closes #301