### PR TITLE
fix: handle Bluesky auth errors and reduce callback URL size

### DIFF
--- a/src/components/auth/BlueSkyLoginComponent.vue
+++ b/src/components/auth/BlueSkyLoginComponent.vue
@@ -82,10 +82,17 @@ const handleBlueskyLogin = async () => {
         const response = await fetch(
           `${baseUrl}/api/v1/auth/bluesky/authorize?handle=${encodeURIComponent(cleanHandle)}&tenantId=${tenantId}`
         )
+
+        if (!response.ok) {
+          const errorText = await response.text()
+          console.error('Auth URL request failed:', response.status, errorText)
+          throw new Error(`Failed to get authorization URL: ${response.status}`)
+        }
+
         const url = await response.text()
 
-        if (!url) {
-          throw new Error('No authorization URL received')
+        if (!url || !url.startsWith('http')) {
+          throw new Error('Invalid authorization URL received')
         }
 
         // Redirect to Bluesky auth in the same window


### PR DESCRIPTION
## Summary
- Add `response.ok` check in BlueSkyLoginComponent to properly handle API errors instead of navigating to error JSON as URL
- Update `handleBlueskyCallback` to fetch user profile via `/auth/me` instead of parsing user from URL params
- Remove redundant user param handling to work with reduced callback URL from API

## Test plan
- [x] Tested Bluesky login on dev environment
- [x] Confirmed error responses are properly handled and displayed
- [x] Verified user profile is correctly fetched after OAuth callback

**Note:** Requires corresponding API changes in openmeet-api (PR #412)