### PR TITLE
feat: update dashboard pages to use new summary endpoints

### DIFF
--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios'
 import { api } from '../boot/axios'
-import { EventAttendeeEntity, EventAttendeePaginationEntity, EventEntity, EventPaginationEntity, ActivityFeedEntity } from '../types'
+import { EventAttendeeEntity, EventAttendeePaginationEntity, EventEntity, EventPaginationEntity, ActivityFeedEntity, DashboardSummaryEntity } from '../types'
 import { RouteQueryAndHash } from 'vue-router'
 
 const createEventApiHeaders = (eventSlug: string) => ({
@@ -53,6 +53,7 @@ export interface EventApiType {
   similarEvents: (slug: string) => Promise<AxiosResponse<EventEntity[]>>
   getAttendees: (slug: string, query: { page: number, limit: number }) => Promise<AxiosResponse<EventAttendeePaginationEntity>>
   getDashboardEvents: () => Promise<AxiosResponse<EventEntity[]>>
+  getDashboardSummary: () => Promise<AxiosResponse<DashboardSummaryEntity>>
   topics: (slug: string) => Promise<AxiosResponse<EventEntity>>
   joinEventChat: (slug: string) => Promise<AxiosResponse<{ matrixRoomId: string }>>
   getICalendar: (slug: string) => Promise<AxiosResponse<string>>
@@ -116,6 +117,7 @@ export const eventsApi: EventApiType = {
   getAttendees: (slug: string, query: { page: number, limit: number }): Promise<AxiosResponse<EventAttendeePaginationEntity>> => api.get<EventAttendeePaginationEntity>(`/api/events/${slug}/attendees`, { params: query, ...createEventApiHeaders(slug) }),
   edit: (slug: string): Promise<AxiosResponse<EventEntity>> => api.get<EventEntity>(`/api/events/${slug}/edit`, createEventApiHeaders(slug)),
   getDashboardEvents: (): Promise<AxiosResponse<EventEntity[]>> => api.get<EventEntity[]>('/api/events/dashboard'),
+  getDashboardSummary: (): Promise<AxiosResponse<DashboardSummaryEntity>> => api.get<DashboardSummaryEntity>('/api/events/dashboard/summary'),
   topics: (slug: string): Promise<AxiosResponse<EventEntity>> => api.get<EventEntity>(`/api/events/${slug}/topics`, createEventApiHeaders(slug)),
   joinEventChat: (slug: string): Promise<AxiosResponse<{ matrixRoomId: string }>> => api.post(`/api/chat/event/${slug}/join`, {}),
   getICalendar: (slug: string): Promise<AxiosResponse<string>> => api.get(`/api/events/${slug}/calendar`, {

--- a/src/api/groups.ts
+++ b/src/api/groups.ts
@@ -1,5 +1,5 @@
 import { api } from '../boot/axios'
-import { EventEntity, GroupEntity, GroupMemberEntity, GroupPaginationEntity, ActivityFeedEntity } from '../types'
+import { EventEntity, GroupEntity, GroupMemberEntity, GroupPaginationEntity, ActivityFeedEntity, DashboardGroupsSummaryEntity } from '../types'
 import { RouteQueryAndHash } from 'vue-router'
 import { AxiosResponse } from 'axios'
 
@@ -33,5 +33,6 @@ export const groupsApi = {
   sendAdminMessage: (slug: string, data: { subject: string, message: string, targetUserIds?: number[] }): Promise<AxiosResponse<{ success: boolean, deliveredCount: number, failedCount: number, messageId: string }>> => api.post(`/api/groups/${slug}/admin-message`, data, createGroupApiHeaders(slug)),
   previewAdminMessage: (slug: string, data: { subject: string, message: string, testEmail: string, targetUserIds?: number[] }): Promise<AxiosResponse<{ message: string }>> => api.post(`/api/groups/${slug}/admin-message/preview`, data, createGroupApiHeaders(slug)),
   contactAdmins: (slug: string, data: { subject: string, message: string, contactType: 'question' | 'report' | 'feedback' }): Promise<AxiosResponse<{ success: boolean, deliveredCount: number, failedCount: number, messageId: string }>> => api.post(`/api/groups/${slug}/contact-admins`, data, createGroupApiHeaders(slug)),
-  getFeed: (slug: string, params?: { limit?: number, offset?: number, visibility?: string[] }): Promise<AxiosResponse<ActivityFeedEntity[]>> => api.get(`/api/groups/${slug}/feed`, { ...createGroupApiHeaders(slug), params })
+  getFeed: (slug: string, params?: { limit?: number, offset?: number, visibility?: string[] }): Promise<AxiosResponse<ActivityFeedEntity[]>> => api.get(`/api/groups/${slug}/feed`, { ...createGroupApiHeaders(slug), params }),
+  getDashboardSummary: (): Promise<AxiosResponse<DashboardGroupsSummaryEntity>> => api.get<DashboardGroupsSummaryEntity>('/api/groups/dashboard/summary')
 }

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,8 +1,10 @@
 import { api } from '../boot/axios'
-import { UserEntity } from '../types'
+import { UserEntity, ProfileSummaryEntity } from '../types'
 
 export const usersApi = {
   getById: (id: string) => api.get<UserEntity>(`/api/v1/users/${id}`),
+  getProfileSummary: (slug: string) => api.get<ProfileSummaryEntity>(`/api/v1/users/${slug}/profile/summary`),
+  /** @deprecated Use getProfileSummary instead for better performance */
   getMemberProfile: (slug: string) => api.get<UserEntity>(`/api/v1/users/${slug}/profile`),
 
   // TODO: Backend needs to implement this endpoint

--- a/src/pages/dashboard/DashboardEventsPage.vue
+++ b/src/pages/dashboard/DashboardEventsPage.vue
@@ -1,101 +1,271 @@
 <template>
-  <q-page padding style="max-width: 1024px" class="q-mx-auto" v-if="loaded">
+  <q-page padding style="max-width: 1024px" class="q-mx-auto q-pb-xl">
+    <SpinnerComponent v-if="!loaded" />
 
-    <div class="row justify-between items-start">
-      <DashboardTitle defaultBack label="Your events" />
-      <q-btn no-caps color="primary" icon="sym_r_add" label="Add New Event" @click="onAddNewEvent" />
-    </div>
+    <template v-if="loaded">
+      <div class="row justify-between items-start">
+        <DashboardTitle defaultBack label="Your events" />
+        <q-btn no-caps color="primary" icon="sym_r_add" label="Add New Event" @click="onAddNewEvent" />
+      </div>
 
-    <q-tabs align="left" no-caps v-model="tab" class="text-primary q-mb-md q-mt-md">
-      <q-tab name="attending" label="Attending Events" />
-      <q-tab name="hosting" label="Hosting Events" />
-      <!-- <q-tab name="saved" label="Saved Events"/> -->
-      <q-tab name="past" label="Past Events" />
-    </q-tabs>
+      <!-- Stats Summary - clean text style -->
+      <div class="text-body2 text-grey-7 q-mt-md q-mb-lg summary-line">
+        <span v-if="summary?.counts.hostingUpcoming">
+          <strong class="text-primary">{{ summary.counts.hostingUpcoming }}</strong> hosting
+        </span>
+        <span v-if="summary?.counts.hostingUpcoming && summary?.counts.attendingUpcoming" class="separator">·</span>
+        <span v-if="summary?.counts.attendingUpcoming">
+          <strong class="text-secondary">{{ summary.counts.attendingUpcoming }}</strong> attending
+        </span>
+        <span v-if="(summary?.counts.hostingUpcoming || summary?.counts.attendingUpcoming) && summary?.counts.past" class="separator">·</span>
+        <span
+          v-if="summary?.counts.past"
+          class="past-link"
+          @click="showPastEvents = true"
+        >
+          <strong>{{ summary.counts.past }}</strong> past
+        </span>
+      </div>
 
-    <q-tab-panels v-model="tab" animated>
-      <q-tab-panel name="attending">
-        <NoContentComponent v-if="attendedEvents && !attendedEvents.length" @click="router.push({ name: 'EventsPage' })"
-          buttonLabel="Discover new events" label="You have not registered for any events" icon="sym_r_event" />
-        <div>
-          <EventsItemComponent v-for="event in attendedEvents" :key="event.id" :event="event" layout="list"/>
+      <!-- No events state -->
+      <NoContentComponent
+        v-if="!hasAnyEvents"
+        @click="onAddNewEvent"
+        buttonLabel="Create your first event"
+        label="You don't have any upcoming events"
+        icon="sym_r_event"
+      />
+
+      <!-- Hosting This Week -->
+      <template v-if="summary?.hostingThisWeek?.length">
+        <div class="text-h6 q-mb-sm flex items-center">
+          <q-icon name="sym_r_calendar_today" class="q-mr-sm" color="primary" />
+          Hosting This Week
+          <q-badge color="primary" class="q-ml-sm">{{ summary.hostingThisWeek.length }}</q-badge>
         </div>
-      </q-tab-panel>
-      <q-tab-panel name="hosting">
-        <template v-if="hostingEvents && !hostingEvents.length">
-          <NoContentComponent @click="onAddNewEvent" buttonLabel="Add new Event and select a group to get started."
-            label="You are not hosting any upcoming events" icon="sym_r_app_registration" />
-        </template>
-        <div v-else>
-          <EventsItemComponent v-for="event in hostingEvents" :key="event.id" :event="event" layout="list"/>
+        <div class="q-mb-lg">
+          <EventsItemComponent
+            v-for="event in summary.hostingThisWeek"
+            :key="event.id"
+            :event="event"
+            layout="list"
+          />
         </div>
-      </q-tab-panel>
+      </template>
 
-      <q-tab-panel name="past">
-
-        <div v-if="pastEvents?.length">
-          <EventsItemComponent v-for="event in pastEvents" :key="event.id" :event="event" layout="list"/>
+      <!-- Hosting Later -->
+      <template v-if="summary?.hostingLater?.length">
+        <div class="text-h6 q-mb-sm flex items-center justify-between">
+          <div class="flex items-center">
+            <q-icon name="sym_r_event_upcoming" class="q-mr-sm" color="primary" />
+            Hosting Later
+            <q-badge v-if="moreHostingCount > 0" color="grey-6" class="q-ml-sm">
+              {{ moreHostingCount }} more
+            </q-badge>
+          </div>
+          <q-btn
+            v-if="moreHostingCount > 0"
+            flat
+            no-caps
+            color="primary"
+            label="View all"
+            icon-right="sym_r_arrow_forward"
+            @click="viewAllHosting"
+          />
         </div>
-        <NoContentComponent v-if="events && !pastEvents.length" @click="router.push({ name: 'EventsPage' })"
-          buttonLabel="Discover new events" label="You have not attended any events" icon="sym_r_timeline" />
-      </q-tab-panel>
-    </q-tab-panels>
+        <div class="q-mb-lg">
+          <EventsItemComponent
+            v-for="event in summary.hostingLater"
+            :key="event.id"
+            :event="event"
+            layout="list"
+          />
+        </div>
+      </template>
+
+      <!-- Attending Soon -->
+      <template v-if="summary?.attendingSoon?.length">
+        <div class="text-h6 q-mb-sm flex items-center justify-between">
+          <div class="flex items-center">
+            <q-icon name="sym_r_how_to_reg" class="q-mr-sm" color="secondary" />
+            Attending Soon
+            <q-badge v-if="moreAttendingCount > 0" color="grey-6" class="q-ml-sm">
+              {{ moreAttendingCount }} more
+            </q-badge>
+          </div>
+          <q-btn
+            v-if="moreAttendingCount > 0"
+            flat
+            no-caps
+            color="primary"
+            label="View all"
+            icon-right="sym_r_arrow_forward"
+            @click="viewAllAttending"
+          />
+        </div>
+        <div class="q-mb-lg">
+          <EventsItemComponent
+            v-for="event in summary.attendingSoon"
+            :key="event.id"
+            :event="event"
+            layout="list"
+          />
+        </div>
+      </template>
+
+      <!-- Past Events Link -->
+      <q-separator v-if="summary?.counts.past" class="q-my-md" />
+      <div v-if="summary?.counts.past" class="text-center">
+        <q-btn
+          flat
+          no-caps
+          color="grey-7"
+          icon="sym_r_history"
+          :label="`Browse ${summary.counts.past} past events`"
+          @click="showPastEvents = true"
+        />
+      </div>
+    </template>
+
+    <!-- Past Events Dialog -->
+    <q-dialog v-model="showPastEvents" maximized>
+      <q-card>
+        <q-card-section class="row items-center q-pb-none">
+          <div class="text-h6">Past Events</div>
+          <q-space />
+          <q-btn icon="close" flat round dense v-close-popup />
+        </q-card-section>
+        <q-card-section class="q-pt-none">
+          <div v-if="loadingPast" class="text-center q-pa-xl">
+            <q-spinner size="lg" color="primary" />
+          </div>
+          <div v-else-if="pastEvents.length">
+            <EventsItemComponent
+              v-for="event in pastEvents"
+              :key="event.id"
+              :event="event"
+              layout="list"
+            />
+          </div>
+          <NoContentComponent
+            v-else
+            label="No past events"
+            icon="sym_r_history"
+          />
+        </q-card-section>
+      </q-card>
+    </q-dialog>
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { LoadingBar, useMeta } from 'quasar'
 import { useRouter } from 'vue-router'
-import { EventAttendeeRole, EventEntity, EventAttendeeStatus } from '../../types'
+import { DashboardSummaryEntity, EventEntity } from '../../types'
 import EventsItemComponent from '../../components/event/EventsItemComponent.vue'
 import DashboardTitle from '../../components/dashboard/DashboardTitle.vue'
+import SpinnerComponent from '../../components/common/SpinnerComponent.vue'
+import NoContentComponent from '../../components/global/NoContentComponent.vue'
 import { eventsApi } from '../../api'
 
-const tab = ref<'attending' | 'hosting' | 'saved' | 'past'>('attending')
-const loaded = ref<boolean>(false)
+const loaded = ref(false)
 const router = useRouter()
+const summary = ref<DashboardSummaryEntity | null>(null)
 
-const events = ref<EventEntity[]>([])
+// Past events state
+const showPastEvents = ref(false)
+const loadingPast = ref(false)
+const pastEvents = ref<EventEntity[]>([])
 
-// Helper: Sort events by startDate ascending (soonest first)
-const sortedEvents = computed(() =>
-  [...events.value].sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
-)
+// Computed values
+const hasAnyEvents = computed(() => {
+  if (!summary.value) return false
+  return (
+    summary.value.hostingThisWeek.length > 0 ||
+    summary.value.hostingLater.length > 0 ||
+    summary.value.attendingSoon.length > 0
+  )
+})
 
-const hostingEvents = computed(() => sortedEvents.value.filter(
-  event => event.attendee?.role.name === EventAttendeeRole.Host &&
-  event.startDate &&
-  new Date(event.startDate) >= new Date()
-))
-const attendedEvents = computed(() => sortedEvents.value.filter(event =>
-  event.attendee &&
-  event.attendee.role.name !== EventAttendeeRole.Host &&
-  event.attendee.status !== EventAttendeeStatus.Cancelled &&
-  event.startDate &&
-  new Date(event.startDate) >= new Date()
-))
-const pastEvents = computed(() =>
-  sortedEvents.value
-    .filter(event => event.startDate && new Date(event.startDate) < new Date())
-    .sort((a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime())
-)
+const moreHostingCount = computed(() => {
+  if (!summary.value) return 0
+  const shown = summary.value.hostingThisWeek.length + summary.value.hostingLater.length
+  return Math.max(0, summary.value.counts.hostingUpcoming - shown)
+})
+
+const moreAttendingCount = computed(() => {
+  if (!summary.value) return 0
+  return Math.max(0, summary.value.counts.attendingUpcoming - summary.value.attendingSoon.length)
+})
 
 useMeta({
   title: 'Your events'
 })
 
-onMounted(() => {
+onMounted(async () => {
   LoadingBar.start()
-  eventsApi.getDashboardEvents().then(res => {
-    events.value = res.data
-  }).finally(() => {
+  try {
+    const res = await eventsApi.getDashboardSummary()
+    summary.value = res.data
+  } finally {
     LoadingBar.stop()
     loaded.value = true
-  })
+  }
+})
+
+// Load past events when dialog opens
+watch(showPastEvents, async (isOpen) => {
+  if (isOpen && pastEvents.value.length === 0) {
+    loadingPast.value = true
+    try {
+      // For now, use the legacy endpoint and filter client-side
+      // TODO: Create a dedicated past events endpoint with pagination
+      const res = await eventsApi.getDashboardEvents()
+      pastEvents.value = res.data
+        .filter(event => event.startDate && new Date(event.startDate) < new Date())
+        .sort((a, b) => new Date(b.startDate).getTime() - new Date(a.startDate).getTime())
+    } finally {
+      loadingPast.value = false
+    }
+  }
 })
 
 const onAddNewEvent = () => {
   router.push({ name: 'DashboardEventCreatePage' })
 }
+
+const viewAllHosting = () => {
+  // TODO: Navigate to paginated hosting events view
+  router.push({ name: 'EventsPage', query: { hosting: 'true' } })
+}
+
+const viewAllAttending = () => {
+  // TODO: Navigate to paginated attending events view
+  router.push({ name: 'EventsPage', query: { attending: 'true' } })
+}
 </script>
+
+<style scoped lang="scss">
+.text-h6 {
+  font-weight: 500;
+}
+
+.summary-line {
+  .separator {
+    margin: 0 0.5rem;
+    color: #ccc;
+  }
+
+  .past-link {
+    cursor: pointer;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+    text-underline-offset: 2px;
+
+    &:hover {
+      color: var(--q-primary);
+    }
+  }
+}
+</style>

--- a/src/pages/dashboard/group/DashboardGroupsPage.vue
+++ b/src/pages/dashboard/group/DashboardGroupsPage.vue
@@ -4,105 +4,117 @@
     <SpinnerComponent v-if="isLoading" />
 
     <div class="row justify-between items-start">
-      <DashboardTitle defaultBack label="Your groups" />
+      <DashboardTitle defaultBack label="Your Groups" />
       <q-btn no-caps color="primary" icon="sym_r_add" label="Create Group"
         @click="onAddNewGroup" />
     </div>
 
-    <template v-if="!isLoading">
-      <q-tabs align="left" no-caps v-model="tab" class="text-primary q-mb-md q-mt-md">
-        <q-tab name="member" label="Member in" />
-        <q-tab name="admin" label="Leader in" />
-        <q-tab name="all" label="All" />
-      </q-tabs>
+    <template v-if="!isLoading && summary">
+      <!-- Stats Summary - clean text style -->
+      <div class="text-body2 text-grey-7 q-mt-md q-mb-lg summary-line">
+        <span v-if="summary.counts.leading">
+          <strong class="text-primary">{{ summary.counts.leading }}</strong> leading
+        </span>
+        <span v-if="summary.counts.leading && summary.counts.member" class="separator">·</span>
+        <span v-if="summary.counts.member">
+          <strong class="text-secondary">{{ summary.counts.member }}</strong> member
+        </span>
+      </div>
 
-      <q-tab-panels v-model="tab" animated>
-        <q-tab-panel name="member">
-          <NoContentComponent v-if="memberedGroups && !memberedGroups.length" @click="exploreGroups"
-            buttonLabel="Explore Groups" label="You haven't joined any groups yet." icon="sym_r_group" />
-          <div v-else class="column q-gutter-y-md">
-            <GroupsItemComponent v-for="group in memberedGroups" :key="group.id" :group="group" layout="list" class="col-12" />
-          </div>
-        </q-tab-panel>
+      <!-- No groups state -->
+      <template v-if="summary.counts.leading === 0 && summary.counts.member === 0">
+        <NoContentComponent
+          @click="exploreGroups"
+          buttonLabel="Explore Groups"
+          label="You haven't joined any groups yet."
+          icon="sym_r_group"
+        />
+      </template>
 
-        <q-tab-panel name="admin">
-          <div v-if="hostedGroups?.length" class="column q-gutter-y-md">
-            <GroupsItemComponent v-for="group in hostedGroups" :key="group.id" :group="group" layout="list" class="col-12" />
-          </div>
-          <NoContentComponent v-else @click="onAddNewGroup" buttonLabel="Add new Group"
-            label="You haven't created any groups yet." icon="sym_r_groups" />
-        </q-tab-panel>
+      <!-- Groups You Lead -->
+      <template v-if="summary.leadingGroups.length > 0">
+        <div class="text-h6 q-mb-md">Groups You Lead</div>
+        <div class="column q-gutter-y-md q-mb-lg">
+          <GroupsItemComponent
+            v-for="group in summary.leadingGroups"
+            :key="group.id"
+            :group="group"
+            layout="list"
+            class="col-12"
+          />
+        </div>
+        <div v-if="summary.counts.leading > summary.leadingGroups.length" class="q-mb-lg">
+          <q-btn
+            flat
+            no-caps
+            color="primary"
+            :label="`View all ${summary.counts.leading} groups you lead`"
+            @click="viewAllLeadingGroups"
+          />
+        </div>
+      </template>
 
-        <q-tab-panel name="all">
-          <NoContentComponent v-if="!userGroups.length" @click="exploreGroups"
-            buttonLabel="Explore Groups" label="You haven't joined any groups yet." icon="sym_r_group" />
-          <div v-else class="column q-gutter-y-md">
-            <GroupsItemComponent v-for="group in userGroups" :key="group.id" :group="group" layout="list" class="col-12" />
-          </div>
-        </q-tab-panel>
-      </q-tab-panels>
+      <!-- Groups You're In -->
+      <template v-if="summary.memberGroups.length > 0">
+        <div class="text-h6 q-mb-md">Groups You're In</div>
+        <div class="column q-gutter-y-md q-mb-lg">
+          <GroupsItemComponent
+            v-for="group in summary.memberGroups"
+            :key="group.id"
+            :group="group"
+            layout="list"
+            class="col-12"
+          />
+        </div>
+        <div v-if="summary.counts.member > summary.memberGroups.length" class="q-mb-lg">
+          <q-btn
+            flat
+            no-caps
+            color="primary"
+            :label="`View all ${summary.counts.member} groups`"
+            @click="viewAllMemberGroups"
+          />
+        </div>
+      </template>
+
+      <!-- Explore more groups -->
+      <div class="q-mt-xl text-center">
+        <q-btn
+          outline
+          no-caps
+          color="primary"
+          icon="sym_r_explore"
+          label="Explore More Groups"
+          @click="exploreGroups"
+        />
+      </div>
     </template>
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue'
+import { onMounted, ref } from 'vue'
 import { LoadingBar, useMeta } from 'quasar'
 import { useRouter } from 'vue-router'
 import { groupsApi } from '../../../api/groups'
-import { GroupEntity } from '../../../types'
+import { DashboardGroupsSummaryEntity } from '../../../types'
 import SpinnerComponent from '../../../components/common/SpinnerComponent.vue'
 import DashboardTitle from '../../../components/dashboard/DashboardTitle.vue'
 import GroupsItemComponent from 'src/components/group/GroupsItemComponent.vue'
 import NoContentComponent from '../../../components/global/NoContentComponent.vue'
 
-// Define extended type that can include the additional properties from backend
-type ExtendedGroupEntity = GroupEntity & {
-  isCreator?: boolean;
-  upcomingEventsCount?: number;
-}
-
 const router = useRouter()
 const isLoading = ref<boolean>(false)
-const userGroups = ref<ExtendedGroupEntity[]>([])
-const tab = ref<'member' | 'admin'>('member')
-
-// Filter groups by checking if user is the creator or a leadership role
-const hostedGroups = computed(() => {
-  return userGroups.value?.filter(group => {
-    // Check for isCreator property first if available
-    if (group.isCreator === true) {
-      return true
-    }
-    // Include groups where user has admin or moderator role
-    const role = group.groupMember?.groupRole?.name
-    if (role === 'admin' || role === 'moderator' || role === 'owner') {
-      return true
-    }
-    return false
-  })
-})
-
-// Filter groups where user is a member but not in leadership role
-const memberedGroups = computed(() => {
-  return userGroups.value?.filter(group => {
-    const role = group.groupMember?.groupRole?.name
-    // Only include regular members, not those with leadership roles
-    return role === 'member'
-  })
-})
+const summary = ref<DashboardGroupsSummaryEntity | null>(null)
 
 useMeta({
-  title: 'Your groups'
+  title: 'Your Groups'
 })
 
 const fetchData = async () => {
   LoadingBar.start()
-  return groupsApi.getDashboardGroups().then(res => {
-    // Cast the response data to our extended type
-    userGroups.value = res.data as ExtendedGroupEntity[]
-    // Sort by name to ensure consistent display
-    userGroups.value.sort((a, b) => a.name.localeCompare(b.name))
+  return groupsApi.getDashboardSummary().then(res => {
+    summary.value = res.data
   }).finally(LoadingBar.stop)
 }
 
@@ -118,6 +130,21 @@ const exploreGroups = () => {
 const onAddNewGroup = () => {
   router.push({ name: 'DashboardGroupCreatePage' })
 }
+
+const viewAllLeadingGroups = () => {
+  router.push({ name: 'GroupsPage', query: { role: 'leader' } })
+}
+
+const viewAllMemberGroups = () => {
+  router.push({ name: 'GroupsPage', query: { role: 'member' } })
+}
 </script>
 
-<style scoped></style>
+<style scoped lang="scss">
+.summary-line {
+  .separator {
+    margin: 0 0.5rem;
+    color: #ccc;
+  }
+}
+</style>

--- a/src/stores/profile-store.ts
+++ b/src/stores/profile-store.ts
@@ -1,21 +1,22 @@
 import { defineStore } from 'pinia'
 import { usersApi } from '../api'
-import { UserEntity } from '../types'
+import { ProfileSummaryEntity } from '../types'
 
 export const useProfileStore = defineStore('profile', {
   state: () => ({
-    user: null as UserEntity | null,
+    profile: null as ProfileSummaryEntity | null,
     isLoading: false
   }),
 
   actions: {
-    actionGetMemberProfile (slug: string) {
+    async actionGetProfileSummary (slug: string) {
       this.isLoading = true
-      return usersApi.getMemberProfile(slug).then(user => {
-        this.user = user.data
-      }).finally(() => {
+      try {
+        const response = await usersApi.getProfileSummary(slug)
+        this.profile = response.data
+      } finally {
         this.isLoading = false
-      })
+      }
     }
   }
 })

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -207,3 +207,17 @@ export interface EventEntity {
 // ======= Pagination Entities =======
 export interface EventPaginationEntity extends Pagination<EventEntity> {}
 export interface EventAttendeePaginationEntity extends Pagination<EventAttendeeEntity> {}
+
+// ======= Dashboard Summary =======
+export interface DashboardEventCounts {
+  hostingUpcoming: number
+  attendingUpcoming: number
+  past: number
+}
+
+export interface DashboardSummaryEntity {
+  counts: DashboardEventCounts
+  hostingThisWeek: EventEntity[]
+  hostingLater: EventEntity[]
+  attendingSoon: EventEntity[]
+}

--- a/src/types/group.ts
+++ b/src/types/group.ts
@@ -106,3 +106,15 @@ export enum GroupPermission {
 }
 
 export interface GroupPaginationEntity extends Pagination<GroupEntity> {}
+
+// ======= Dashboard Summary =======
+export interface DashboardGroupCounts {
+  leading: number
+  member: number
+}
+
+export interface DashboardGroupsSummaryEntity {
+  counts: DashboardGroupCounts
+  leadingGroups: GroupEntity[]
+  memberGroups: GroupEntity[]
+}

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -105,3 +105,30 @@ export interface UserEntity {
   interests?: SubCategoryEntity[]
   preferences?: UserPreferences
 }
+
+// ======= Profile Summary =======
+export interface ProfileCounts {
+  organizedEvents: number
+  attendingEvents: number
+  ownedGroups: number
+  groupMemberships: number
+}
+
+export interface ProfileSummaryEntity {
+  id: number
+  slug: string
+  firstName?: string
+  lastName?: string
+  bio?: string
+  photo?: { id: string; path: string }
+  provider?: string
+  socialId?: string
+  isShadowAccount?: boolean
+  preferences?: UserPreferences
+  counts: ProfileCounts
+  interests: SubCategoryEntity[]
+  organizedEvents: EventEntity[]
+  attendingEvents: AttendingEvent[]
+  ownedGroups: GroupEntity[]
+  groupMemberships: GroupMemberEntity[]
+}


### PR DESCRIPTION
## Summary
- Update events, groups, and profile pages to use new optimized summary endpoints
- Cleaner UI with text-based stats instead of busy chips
- Better loading states and "view all" links

## Changes
- **Events dashboard**: Uses `/events/dashboard/summary` for counts + this week/later/attending previews
- **Groups dashboard**: Uses `/groups/dashboard/summary` for counts + leading/member previews
- **Profile page**: Uses `/users/:identifier/profile/summary` for activity counts + previews

## UI Improvements
- Stats display: `1 hosting · 2 attending · 31 past` (cleaner than chips)
- "View all" buttons when more items exist than shown
- Past events dialog loads on-demand

## Dependencies
Requires OpenMeet-Team/openmeet-api#416 to be merged first

## Test plan
- [x] Events dashboard shows correct counts and limited event previews
- [x] Groups dashboard shows correct counts and limited group previews  
- [x] Profile page shows activity counts and limited previews
- [ ] "View all" links appear when there are more items
- [ ] Past events dialog loads correctly