### PR TITLE
fix: add 'See all' links on own profile to navigate to dashboard

### DIFF
--- a/src/pages/MemberPage.vue
+++ b/src/pages/MemberPage.vue
@@ -386,6 +386,9 @@ const loadBlueskyEvents = async () => {
                 :loading="profileStore.isLoading"
                 empty-message="There are no groups yet."
                 layout="grid"
+                :hide-link="!isOwnProfile"
+                :to="{ name: 'DashboardMyGroupsPage', query: { role: 'leader' } }"
+                link-text="See all"
               />
             </q-card-section>
           </q-card>
@@ -395,7 +398,8 @@ const loadBlueskyEvents = async () => {
             <q-card-section>
               <SubtitleComponent
                 :count="counts?.organizedEvents || organizedEvents.length"
-                hide-link
+                :hide-link="!isOwnProfile"
+                :to="{ name: 'DashboardMyEventsPage', query: { tab: 'hosting' } }"
                 :label="counts && counts.organizedEvents > organizedEvents.length ? `Organized Events (showing ${organizedEvents.length})` : 'Organized Events'"
               />
               <EventsItemComponent
@@ -411,7 +415,8 @@ const loadBlueskyEvents = async () => {
             <q-card-section>
               <SubtitleComponent
                 :count="counts?.attendingEvents || attendingEvents.length"
-                hide-link
+                :hide-link="!isOwnProfile"
+                :to="{ name: 'DashboardMyEventsPage', query: { tab: 'attending' } }"
                 :label="counts && counts.attendingEvents > attendingEvents.length ? `Attending Events (showing ${attendingEvents.length})` : 'Attending Events'"
               />
               <EventsItemComponent
@@ -427,7 +432,8 @@ const loadBlueskyEvents = async () => {
             <q-card-section>
               <SubtitleComponent
                 :count="counts?.groupMemberships || groupMemberships.length"
-                hide-link
+                :hide-link="!isOwnProfile"
+                :to="{ name: 'DashboardMyGroupsPage', query: { role: 'member' } }"
                 :label="counts && counts.groupMemberships > groupMemberships.length ? `Group Memberships (showing ${groupMemberships.length})` : 'Group Memberships'"
               />
               <GroupsItemComponent


### PR DESCRIPTION
## Summary
- When viewing your own profile, "See all" links now appear on events/groups sections
- Links navigate to the appropriate dashboard pages with correct query params
- Links remain hidden when viewing other users' profiles

## Changes
| Section | Destination |
|---------|-------------|
| Organized Events | `/dashboard/events/all?tab=hosting` |
| Attending Events | `/dashboard/events/all?tab=attending` |
| Owned Groups | `/dashboard/groups/all?role=leader` |
| Group Memberships | `/dashboard/groups/all?role=member` |

## Test plan
- [x] Navigate to your own profile page
- [x] Verify "See all" links appear on each section (when items > 5)
- [x] Click each link and verify it navigates to the correct dashboard page with the right tab/filter selected
- [x] Navigate to another user's profile
- [x] Verify "See all" links do NOT appear

Closes #306