### PR TITLE
fix: improve accessibility by adding aria-labels to buttons and menus

### DIFF
--- a/src/components/calendar/CalendarConnectionsComponent.vue
+++ b/src/components/calendar/CalendarConnectionsComponent.vue
@@ -421,6 +421,7 @@ const createIcalSource = async () => {
               :loading="syncing[source.ulid]"
               @click="syncCalendar(source)"
               :disable="!source.isActive"
+              aria-label="Sync calendar now"
             >
               <q-tooltip>Sync Now</q-tooltip>
             </q-btn>
@@ -434,6 +435,7 @@ const createIcalSource = async () => {
               :loading="testing[source.ulid]"
               @click="testConnection(source)"
               :disable="!source.isActive"
+              aria-label="Test calendar connection"
             >
               <q-tooltip>Test Connection</q-tooltip>
             </q-btn>
@@ -445,6 +447,7 @@ const createIcalSource = async () => {
               icon="sym_r_delete"
               color="negative"
               @click="disconnectCalendar(source)"
+              aria-label="Disconnect calendar"
             >
               <q-tooltip>Disconnect</q-tooltip>
             </q-btn>

--- a/src/components/chat/ChatListPanel.vue
+++ b/src/components/chat/ChatListPanel.vue
@@ -91,6 +91,7 @@
           icon="sym_r_settings"
           size="sm"
           class="q-px-sm"
+          aria-haspopup="menu"
         >
           <q-menu>
             <q-list style="min-width: 150px">

--- a/src/components/chat/MatrixChatInterface.vue
+++ b/src/components/chat/MatrixChatInterface.vue
@@ -19,6 +19,7 @@
           icon="sym_r_more_vert"
           flat
           round
+          aria-haspopup="menu"
         >
           <q-menu>
             <q-list style="min-width: 180px">

--- a/src/components/chat/encryption/PassphraseUnlockDialog.vue
+++ b/src/components/chat/encryption/PassphraseUnlockDialog.vue
@@ -9,7 +9,7 @@
         <button
           class="close-button"
           @click="handleCancel"
-          aria-label="Close"
+          aria-label="Close Unlock Encryption dialog"
         >
           <XIcon class="close-icon" />
         </button>

--- a/src/components/common/QRCodeComponent.vue
+++ b/src/components/common/QRCodeComponent.vue
@@ -24,13 +24,13 @@
           <q-btn label="Copy link" color="primary" class="q-mt-md center" @click="copyToClipboard" />
 
           <!-- Share Buttons Section -->
-            <div class="q-mt-md flex justify-center">
+          <div class="q-mt-md flex justify-center">
             <q-btn icon="fab fa-facebook" color="blue" flat aria-label="Share on Facebook" @click="shareOnPlatform('facebook')" />
             <q-btn icon="fab fa-twitter" color="blue" flat aria-label="Share on Twitter" @click="shareOnPlatform('twitter')" />
             <q-btn icon="fab fa-linkedin" color="blue" flat aria-label="Share on LinkedIn" @click="shareOnPlatform('linkedin')" />
             <q-btn icon="fab fa-whatsapp" color="green" flat aria-label="Share on WhatsApp" @click="shareOnPlatform('whatsapp')" />
             <q-btn icon="fas fa-envelope" color="red" flat aria-label="Share via Email" @click="shareOnPlatform('email')" />
-            </div>
+          </div>
         </q-card-section>
       </q-card>
     </q-dialog>

--- a/src/components/event/ContactEventOrganizersDialogComponent.vue
+++ b/src/components/event/ContactEventOrganizersDialogComponent.vue
@@ -4,7 +4,7 @@
       <q-card-section class="row items-center q-pb-none">
         <div class="text-h6">Contact Event Organizers</div>
         <q-space />
-        <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close dialog" />
+        <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close Contact Event Organizers dialog" />
       </q-card-section>
 
       <q-card-section>

--- a/src/components/event/EventAdminMessageDialogComponent.vue
+++ b/src/components/event/EventAdminMessageDialogComponent.vue
@@ -4,7 +4,7 @@
       <q-card-section class="row items-center q-pb-none">
         <div class="text-h6">Send Message to Event Attendees</div>
         <q-space />
-        <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close dialog" />
+        <q-btn icon="sym_r_close" flat round dense v-close-popup :aria-label="event ? `Close dialog for ${event.name}` : 'Close dialog'" />
       </q-card-section>
 
       <q-card-section>

--- a/src/components/event/RecurrenceCalendarComponent.vue
+++ b/src/components/event/RecurrenceCalendarComponent.vue
@@ -9,9 +9,9 @@
 
         <!-- Month navigation -->
         <div class="row items-center justify-between q-mb-md">
-            <q-btn icon="sym_r_chevron_left" flat dense round @click="previousMonth" :aria-label="`Previous month, ${currentMonthName} ${currentYear}`" />
-            <span class="text-subtitle1" aria-label="Current month and year">{{ currentMonthName }} {{ currentYear }}</span>
-            <q-btn icon="sym_r_chevron_right" flat dense round @click="nextMonth" :aria-label="`Next month, ${currentMonthName} ${currentYear}`" />
+          <q-btn icon="sym_r_chevron_left" flat dense round @click="previousMonth" :aria-label="`Previous month, ${currentMonthName} ${currentYear}`" />
+          <span class="text-subtitle1" aria-label="Current month and year">{{ currentMonthName }} {{ currentYear }}</span>
+          <q-btn icon="sym_r_chevron_right" flat dense round @click="nextMonth" :aria-label="`Next month, ${currentMonthName} ${currentYear}`" />
         </div>
 
         <!-- Calendar grid -->

--- a/src/components/event/RecurrenceSplitDialogComponent.vue
+++ b/src/components/event/RecurrenceSplitDialogComponent.vue
@@ -4,7 +4,7 @@
       <q-card-section class="row items-center">
         <div class="text-h6">Split Recurring Series</div>
         <q-space />
-        <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close dialog" />
+        <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close Split Recurring Series dialog" />
       </q-card-section>
 
       <q-card-section>

--- a/src/components/group/AdminMessageDialogComponent.vue
+++ b/src/components/group/AdminMessageDialogComponent.vue
@@ -4,7 +4,7 @@
       <q-card-section class="row items-center q-pb-none">
         <div class="text-h6">Send Message to Group Members</div>
         <q-space />
-        <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close dialog" />
+        <q-btn icon="sym_r_close" flat round dense v-close-popup :aria-label="group?.name ? `Close dialog: Send message to ${group.name}` : 'Close dialog'" />
       </q-card-section>
 
       <q-card-section>

--- a/src/components/group/ContactAdminsDialogComponent.vue
+++ b/src/components/group/ContactAdminsDialogComponent.vue
@@ -4,7 +4,7 @@
       <q-card-section class="row items-center q-pb-none">
         <div class="text-h6">Contact Group Admins</div>
         <q-space />
-        <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close dialog" />
+        <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close Contact Group Admins dialog" />
       </q-card-section>
 
       <q-card-section>

--- a/src/components/header/HeaderNotificationsComponent.vue
+++ b/src/components/header/HeaderNotificationsComponent.vue
@@ -6,6 +6,7 @@
     dense
     icon="sym_r_notifications"
     class="notifications-dropdown q-mr-md"
+    aria-haspopup="menu"
   >
     <q-badge
       v-if="unreadCount > 0"

--- a/src/components/header/HeaderProfileComponent.vue
+++ b/src/components/header/HeaderProfileComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-avatar class="cursor-pointer" v-if="useAuthStore().isAuthenticated">
+  <q-avatar class="cursor-pointer" v-if="useAuthStore().isAuthenticated" aria-haspopup="menu">
     <template v-if="avatarUrl">
       <img data-cy="header-profile-avatar" :src="avatarUrl" alt="avatar">
     </template>

--- a/src/pages/EventPage.vue
+++ b/src/pages/EventPage.vue
@@ -941,7 +941,7 @@
         <q-card-section class="row items-center q-pb-none">
           <div class="text-h6">QR Code</div>
           <q-space />
-          <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close dialog" />
+          <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close QR Code dialog" />
         </q-card-section>
 
         <q-card-section class="q-pt-none">

--- a/src/pages/dashboard/DashboardEventsPage.vue
+++ b/src/pages/dashboard/DashboardEventsPage.vue
@@ -143,7 +143,7 @@
         <q-card-section class="row items-center q-pb-none">
           <div class="text-h6">Past Events</div>
           <q-space />
-          <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close dialog" />
+          <q-btn icon="sym_r_close" flat round dense v-close-popup aria-label="Close Past Events dialog" />
         </q-card-section>
         <q-card-section class="q-pt-none">
           <div v-if="loadingPast" class="text-center q-pa-xl">

--- a/src/pages/group/GroupMembersPage.vue
+++ b/src/pages/group/GroupMembersPage.vue
@@ -39,7 +39,7 @@
           <q-item-section top side>
           <div class="text-grey-8 q-gutter-xs">
             <q-btn color="primary" :disable="member.user.slug === useAuthStore().user?.slug" size="md" @click="navigateToChat({ user: member.user.slug })" round flat icon="sym_r_chat" :aria-label="'Message ' + (member.user?.name || member.user?.slug)" />
-            <q-btn color="primary" size="md" round flat icon="sym_r_more_vert" :disable="!(useGroupStore().getterUserHasPermission(GroupPermission.ManageMembers) && member.groupRole.name !== GroupRole.Owner)" :aria-label="'Open actions for ' + (member.user?.name || member.user?.slug)">
+            <q-btn color="primary" size="md" round flat icon="sym_r_more_vert" aria-haspopup="menu" :disable="!(useGroupStore().getterUserHasPermission(GroupPermission.ManageMembers) && member.groupRole.name !== GroupRole.Owner)" :aria-label="'Open actions for ' + (member.user?.name || member.user?.slug)">
               <q-menu>
                 <q-list>
                   <!-- <MenuItemComponent v-if="member.groupRole.name === GroupRole.Guest" label="Approve" @click="openGroupMemberRoleDialog(group, member)" icon="sym_r_check"/> -->


### PR DESCRIPTION
## High Priority

- Added `aria-haspopup="menu"` to menu trigger buttons for improved screen reader context  
  - Includes **GroupMembersPage** and other menu triggers for consistency
- Added missing `aria-label`s to calendar management icon-only buttons:
  - **Sync calendar now**
  - **Test calendar connection**
  - **Disconnect calendar**

## Medium Priority

- Fixed indentation issues introduced in PR #315:
  - `QRCodeComponent.vue`
  - `RecurrenceCalendarComponent.vue`
- Added `aria-label`s to remaining icon-only buttons across the codebase  

