### PR TITLE
fix: add .dockerignore and align CI to Node 24

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,43 @@
+# Dependencies - installed fresh in container
+node_modules
+
+# Build outputs
+dist
+.quasar
+
+# Git
+.git
+.gitignore
+
+# Test artifacts
+coverage
+test/cypress/videos
+test/cypress/screenshots
+test/cypress/downloads
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
+
+# Environment files (should not be in image)
+.env
+.env.*
+!.env.example
+
+# Development files
+*.log
+npm-debug.log*
+
+# Docker files (not needed in image)
+docker-compose*.yml
+Dockerfile*
+
+# Documentation
+*.md
+!README.md
+
+# Local development
+.DS_Store
+Thumbs.db

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.20.4
+          node-version: 24
           cache: 'npm'
 
       - name: Install Dependencies


### PR DESCRIPTION
## Summary
- Add `.dockerignore` to reduce Docker build context from 1.24GB to ~700KB
- Update CI workflow to use Node 24 (was 18.20.4) to match Dockerfile

## Details
The `.dockerignore` excludes node_modules, dist, test artifacts, and other dev files from the build context. This doesn't affect the final image size (still ~35MB) but significantly speeds up local Docker builds.

The CI workflow was still using Node 18.20.4 while all Docker configurations now use Node 24. This aligns them for consistency.

## Test plan
- [x] Local Docker build tested successfully
- [x] Context transfer verified: 1.24GB → 707KB