### PR TITLE
fix(profile): disable Bluesky events list on profile page

### DIFF
--- a/src/pages/MemberPage.vue
+++ b/src/pages/MemberPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, computed, ref } from 'vue'
+import { onMounted, computed } from 'vue'
 import { LoadingBar } from 'quasar'
 import { useAvatarUrl } from '../composables/useAvatarUrl'
 import { useProfileStore } from '../stores/profile-store'
@@ -12,8 +12,6 @@ import GroupsItemComponent from '../components/group/GroupsItemComponent.vue'
 import EventsItemComponent from '../components/event/EventsItemComponent.vue'
 import GroupsListComponent from '../components/group/GroupsListComponent.vue'
 import { AuthProvidersEnum } from '../types'
-import { blueskyApi } from '../api/bluesky'
-import { BlueskyEvent } from '../types/bluesky-event'
 
 const route = useRoute()
 const profileStore = useProfileStore()
@@ -91,65 +89,11 @@ const isOwnProfile = computed(() => {
   return profile.value && authStore.user && profile.value.id === authStore.user.id
 })
 
-// Bluesky events
-const blueskyEvents = ref<BlueskyEvent[]>([])
-const showDeleteConfirm = ref(false)
-const deletingEvent = ref<string | null>(null)
-const eventToDelete = ref<BlueskyEvent | null>(null)
-
-const confirmDelete = (event: BlueskyEvent) => {
-  if (!event?.value?.name) {
-    return
-  }
-  eventToDelete.value = event
-  showDeleteConfirm.value = true
-}
-
-const deleteEvent = async () => {
-  if (!eventToDelete.value || !authStore.getBlueskyDid) return
-
-  try {
-    deletingEvent.value = eventToDelete.value.uri
-    // Extract the record key from the URI (format: at://did:plc:xxx/community.lexicon.calendar.event/recordkey)
-    const uriParts = eventToDelete.value.uri.split('/')
-    const rkey = uriParts[uriParts.length - 1]
-
-    if (!rkey) {
-      throw new Error('Invalid event URI: Could not extract record key')
-    }
-
-    await blueskyApi.deleteEvent(authStore.getBlueskyDid, rkey)
-    await loadBlueskyEvents()
-    showDeleteConfirm.value = false
-  } catch (err) {
-    console.error('Failed to delete Bluesky event:', err)
-  } finally {
-    deletingEvent.value = null
-    eventToDelete.value = null
-  }
-}
-
 onMounted(async () => {
   LoadingBar.start()
-  await Promise.all([
-    profileStore.actionGetProfileSummary(route.params.slug as string),
-    // Fetch Bluesky events if this is a Bluesky user and it's the current user viewing their own profile
-    isBskyUser.value && isOwnProfile.value && authStore.getBlueskyDid
-      ? loadBlueskyEvents() : Promise.resolve()
-  ]).finally(() => LoadingBar.stop())
+  await profileStore.actionGetProfileSummary(route.params.slug as string)
+    .finally(() => LoadingBar.stop())
 })
-
-const loadBlueskyEvents = async () => {
-  try {
-    const response = await blueskyApi.listEvents(authStore.getBlueskyDid)
-
-    blueskyEvents.value = (response.data || []).filter(event => {
-      return event?.value?.name && event?.value?.startsAt
-    })
-  } catch (err) {
-    console.error('Failed to load Bluesky events:', err)
-  }
-}
 </script>
 
 <template>
@@ -241,93 +185,6 @@ const loadBlueskyEvents = async () => {
                 </div>
               </div>
             </q-card-section>
-
-            <!-- Add Bluesky Events Section (only shown if this is the user's own profile) -->
-            <q-card-section v-if="blueskyEvents?.length > 0 && isOwnProfile">
-              <div class="text-h6 q-mb-md">AT Protocol Events</div>
-              <div class="q-gutter-y-md">
-                <q-card flat bordered v-for="event in blueskyEvents" :key="event.uri" class="event-card">
-                  <q-card-section>
-                    <!-- Header with title and delete button -->
-                    <div class="row items-center justify-between q-mb-sm">
-                      <div class="text-h6">{{ event.value?.name }}</div>
-                      <q-btn
-                        flat
-                        round
-                        color="grey-6"
-                        icon="delete"
-                        size="sm"
-                        :loading="deletingEvent === event.uri"
-                        @click="confirmDelete(event)"
-                      />
-                    </div>
-
-                    <!-- Event time -->
-                    <div class="text-subtitle2 text-grey-8 q-mb-md">
-                      {{ new Date(event.value?.startsAt).toLocaleString() }}
-                    </div>
-
-                    <!-- Description -->
-                    <div v-if="event.value?.description" class="text-body1 q-mb-md">
-                      {{ event.value.description }}
-                    </div>
-
-                    <!-- Info section -->
-                    <div class="q-gutter-y-sm">
-                      <!-- Locations -->
-                      <div v-for="(loc, index) in event.value?.locations" :key="'loc-' + index">
-                        <template v-if="loc.type === 'community.lexicon.location.geo'">
-                          <div class="row items-center text-grey-8">
-                            <q-icon name="place" size="18px" class="q-mr-sm" />
-                            <span>{{ loc.description }}</span>
-                          </div>
-                        </template>
-                      </div>
-
-                      <!-- Links -->
-                      <div v-for="(uri, index) in event.value?.uris" :key="'uri-' + index">
-                        <div class="row items-center">
-                          <q-icon
-                            :name="uri.name === 'Event Image' ? 'image' : 'link'"
-                            size="18px"
-                            class="q-mr-sm text-grey-8"
-                          />
-                          <a
-                            :href="uri.uri"
-                            target="_blank"
-                            class="text-primary"
-                          >
-                            {{ uri.name || uri.uri }}
-                          </a>
-                        </div>
-                      </div>
-                    </div>
-                  </q-card-section>
-                </q-card>
-              </div>
-            </q-card-section>
-
-            <!-- Delete Confirmation Dialog -->
-            <q-dialog v-model="showDeleteConfirm">
-              <q-card>
-                <q-card-section>
-                  <div class="text-h6">Delete Event</div>
-                </q-card-section>
-                <q-card-section>
-                  Are you sure you want to delete "{{ eventToDelete?.value?.name || 'this event' }}"?
-                </q-card-section>
-                <q-card-actions align="right">
-                  <q-btn flat label="Cancel" v-close-popup />
-                  <q-btn
-                    flat
-                    label="Delete"
-                    color="negative"
-                    :loading="!!deletingEvent"
-                    @click="deleteEvent"
-                  />
-                </q-card-actions>
-              </q-card>
-            </q-dialog>
           </q-card>
           <!-- Google Info -->
           <q-card flat bordered class="q-mt-md" v-if="isGoogleUser && profile">
@@ -468,42 +325,6 @@ const loadBlueskyEvents = async () => {
   .separator {
     margin: 0 0.5rem;
     color: #ccc;
-  }
-}
-
-.event-card {
-  border: 1px solid rgba(0, 0, 0, 0.12);
-  border-radius: 8px;
-  transition: box-shadow 0.2s ease;
-
-  &:hover {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-  }
-
-  .text-h6 {
-    font-size: 1.1rem;
-    line-height: 1.4;
-  }
-
-  .text-subtitle2 {
-    color: rgba(0, 0, 0, 0.6);
-  }
-
-  .text-body1 {
-    font-size: 0.95rem;
-    line-height: 1.5;
-    white-space: pre-line;
-  }
-
-  .q-icon {
-    opacity: 0.7;
-  }
-
-  a {
-    text-decoration: none;
-    &:hover {
-      text-decoration: underline;
-    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove AT Protocol Events section from MemberPage that was showing user's Bluesky calendar events
- This feature was causing issues (events not loading on first visit) and is not needed at this time

## Changes
- Remove Bluesky events API calls and state management
- Remove AT Protocol Events UI section and delete functionality  
- Remove related CSS styles

## Test plan
- [x] Profile page loads without errors
- [x] No console errors related to Bluesky events