### PR TITLE
fix:  Updating copyright year to 2026  (#341)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2024 OpenMeet
+Copyright 2026 OpenMeet
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Overview
This PR updates all copyright year references to 2026 to keep licensing information current.