### PR TITLE
fix: make lastName optional on profile page

### DIFF
--- a/src/components/dashboard/DashboardProfileForm.vue
+++ b/src/components/dashboard/DashboardProfileForm.vue
@@ -40,7 +40,6 @@
               filled
               v-model="form.lastName"
               label="Last Name"
-              :rules="[(val: string) => !!val || 'Last name is required']"
             />
 
             <div class="q-mb-md">


### PR DESCRIPTION
## Summary

- Remove required validation rule from lastName field on profile form
- Allows users to save profile without a last name

## Related

- Companion to OpenMeet-Team/openmeet-api#446 which makes lastName optional in registration

## Test plan

- [x] Go to /dashboard/profile
- [x] Clear the Last Name field
- [x] Click Update Profile
- [x] Verify form submits successfully without lastName validation error