### PR TITLE
feat(auth): add UI for Bluesky account merge with Quick RSVP

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -107,6 +107,7 @@ export const authApi = {
   verifyEmailCode: (data: {
     code: string
     email: string
+    context?: 'login' | 'account-merge'
   }): Promise<AxiosResponse<ApiAuthLoginResponse>> =>
     api.post(`${BASE_URL}/verify-email-code`, data, { withCredentials: true }),
 

--- a/src/pages/auth/CollectEmailPage.vue
+++ b/src/pages/auth/CollectEmailPage.vue
@@ -6,12 +6,24 @@
         <div class="text-subtitle2">Please provide your email address to continue</div>
       </q-card-section>
 
+      <!-- Banner for merge scenario -->
+      <q-banner v-if="mergeDetected" class="bg-info text-white q-mb-md" rounded>
+        <template v-slot:avatar>
+          <q-icon name="sym_r_merge" color="white" />
+        </template>
+        <div class="text-body2">
+          We found an existing account with this email. Enter the verification code
+          we sent to complete the merge. Your RSVPs will be preserved.
+        </div>
+      </q-banner>
+
       <q-card-section>
         <q-form @submit="onEmailSubmit" class="q-gutter-md">
           <q-input
             v-model="email"
             label="Email"
             type="email"
+            :disable="mergeDetected"
             :rules="[
               val => !!val || 'Email is required',
               val => /^[^@]+@[^@]+\.[^@]+$/.test(val) || 'Please enter a valid email'
@@ -24,14 +36,30 @@
 
           <q-card-actions align="right" class="q-mt-md">
             <q-btn
+              v-if="!mergeDetected"
               label="Submit"
               type="submit"
               color="primary"
               :loading="loading"
             />
+            <q-btn
+              v-else
+              label="Enter Verification Code"
+              color="primary"
+              @click="showVerificationDialog = true"
+            />
           </q-card-actions>
         </q-form>
       </q-card-section>
+
+      <!-- Verification Dialog for account merge -->
+      <VerifyEmailCodeDialog
+        v-model="showVerificationDialog"
+        :email="email"
+        :verification-code="devVerificationCode"
+        context="account-merge"
+        @success="onMergeSuccess"
+      />
     </q-card>
   </q-page>
 </template>
@@ -41,11 +69,25 @@ import { ref } from 'vue'
 import { useAuthStore } from '../../stores/auth-store'
 import { useNotification } from '../../composables/useNotification'
 import { authApi } from '../../api/auth'
+import VerifyEmailCodeDialog from '../../components/auth/VerifyEmailCodeDialog.vue'
+import getEnv from '../../utils/env'
 
 const authStore = useAuthStore()
 const { success, error: showError } = useNotification()
 const email = ref('')
 const loading = ref(false)
+const mergeDetected = ref(false)
+const showVerificationDialog = ref(false)
+const devVerificationCode = ref<string | undefined>()
+
+const isDevelopment = getEnv('NODE_ENV') === 'development'
+
+interface MergeConflictResponse {
+  status: number
+  mergeAvailable: boolean
+  message: string
+  verificationCode?: string
+}
 
 const onEmailSubmit = async () => {
   loading.value = true
@@ -59,18 +101,54 @@ const onEmailSubmit = async () => {
     authStore.actionSetUser(response.data)
     success('Email updated successfully')
     window.location.replace('/')
-  } catch (err) {
+  } catch (err: unknown) {
     console.error('Failed to update email:', err)
+
+    // Check if it's a merge scenario (409 Conflict with mergeAvailable)
+    if (err && typeof err === 'object' && 'response' in err) {
+      const apiError = err as { response?: { status?: number; data?: MergeConflictResponse } }
+
+      if (apiError.response?.status === 409 && apiError.response?.data?.mergeAvailable) {
+        // Merge scenario detected - verification code was already sent by backend
+        mergeDetected.value = true
+
+        // Store dev verification code if provided
+        if (isDevelopment && apiError.response.data.verificationCode) {
+          devVerificationCode.value = apiError.response.data.verificationCode
+        }
+
+        // Show the verification dialog
+        showVerificationDialog.value = true
+        success('Verification code sent to your email')
+        return
+      }
+
+      // Not eligible for merge - show the error message
+      if (apiError.response?.status === 409) {
+        showError(apiError.response.data?.message || 'This email is already in use by another account.')
+        return
+      }
+    }
+
+    // Generic error
     showError('Failed to update email')
   } finally {
     loading.value = false
   }
+}
+
+const onMergeSuccess = () => {
+  // Verification was successful, user is now logged in as merged account
+  // Redirect to home after a brief delay
+  setTimeout(() => {
+    window.location.replace('/')
+  }, 1000)
 }
 </script>
 
 <style lang="scss" scoped>
 .auth-card {
   width: 100%;
-  max-width: 400px;
+  max-width: 500px;
 }
 </style>


### PR DESCRIPTION
## Summary
- Frontend companion to OpenMeet-Team/openmeet-api#454
- Handles 409 response with `mergeAvailable: true` from PATCH /auth/me
- Shows merge info banner and verification dialog
- On successful verification, redirects user to home

## Files Changed
- `src/pages/auth/CollectEmailPage.vue` - Handle merge 409 response, show merge UI
- `src/components/auth/VerifyEmailCodeDialog.vue` - Add context prop for account-merge context
- `src/api/auth.ts` - Add context parameter to verifyEmailCode API call

## Test plan
- [ ] Manual test: Log in with Bluesky (new account, no email)
- [ ] Navigate to profile / CollectEmailPage
- [ ] Enter email that matches existing Quick RSVP account
- [ ] Should see merge info banner and verification dialog
- [ ] Enter verification code
- [ ] Should redirect to home with merged account

**Backend PR:** OpenMeet-Team/openmeet-api#454