### PR TITLE
feat(ui): show "Former member" fallback for deleted user references

### DIFF
--- a/src/components/event/EventLeadComponent.vue
+++ b/src/components/event/EventLeadComponent.vue
@@ -37,6 +37,16 @@ const userIdentifier = computed(() => {
         <q-item-label class="text-bold cursor-pointer"><router-link class="router-link-inherit" :to="{ name: 'MemberPage', params: { slug: userIdentifier } }">{{ event.user.name }}</router-link></q-item-label>
       </div>
     </div>
+    <!-- Fallback for events where the creator's account was deleted -->
+    <div v-else class="row items-center q-py-sm q-px-md">
+      <q-avatar size="48px" color="grey-4" class="q-mr-md">
+        <q-icon name="sym_r_person_off" color="grey-7" size="24px" />
+      </q-avatar>
+      <div>
+        <q-item-label>Hosted by</q-item-label>
+        <q-item-label class="text-grey-7">Former member</q-item-label>
+      </div>
+    </div>
 </template>
 
 <style scoped lang="scss">

--- a/src/components/group/GroupAboutMembersComponent.vue
+++ b/src/components/group/GroupAboutMembersComponent.vue
@@ -42,6 +42,16 @@ const onMemberClick = (member: GroupMemberEntity) => {
               <q-item-label class="cursor-pointer text-body1" @click="navigateToMember(group.createdBy)">{{ group.createdBy?.name }}</q-item-label>
             </q-item-section>
           </template>
+          <template v-else>
+            <q-item-section avatar>
+              <q-avatar color="grey-4">
+                <q-icon name="sym_r_person_off" color="grey-7" />
+              </q-avatar>
+            </q-item-section>
+            <q-item-section>
+              <q-item-label class="text-body1 text-grey-7">Former member</q-item-label>
+            </q-item-section>
+          </template>
         </q-item>
       </q-list>
     </q-card-section>

--- a/src/components/group/GroupLeadComponent.vue
+++ b/src/components/group/GroupLeadComponent.vue
@@ -65,7 +65,11 @@ const isGroupMember = computed(() => useGroupStore().getterUserIsGroupMember())
           </div>
           <div class="row items-start q-mt-xs" v-if="group.createdBy">
             <q-icon size="sm" left name="sym_r_person" class="text-purple-300"/>
-            <div class="text-body1 cursor-pointer">Organized by <span class="router-link-inherit" v-if="group.createdBy" @click.stop="navigateToMember(group.createdBy)">{{ group.createdBy.name }}</span></div>
+            <div class="text-body1 cursor-pointer">Organized by <span class="router-link-inherit" @click.stop="navigateToMember(group.createdBy)">{{ group.createdBy.name }}</span></div>
+          </div>
+          <div class="row items-start q-mt-xs" v-else>
+            <q-icon size="sm" left name="sym_r_person_off" class="text-grey-5"/>
+            <div class="text-body1 text-grey-7">Organized by former member</div>
           </div>
         </q-card-section>
 

--- a/src/pages/EventSeriesPage.vue
+++ b/src/pages/EventSeriesPage.vue
@@ -46,6 +46,10 @@
               <div class="text-subtitle2">Created by</div>
               <div>{{ eventSeries.user.firstName }} {{ eventSeries.user.lastName }}</div>
             </div>
+            <div class="col-12 col-md-6" v-else>
+              <div class="text-subtitle2">Created by</div>
+              <div class="text-grey-7">Former member</div>
+            </div>
 
             <!-- Recurrence pattern -->
             <div class="col-12">


### PR DESCRIPTION
## Summary
- Shows graceful "Former member" fallback when event/group creators have been deleted
- Prevents UI crashes from null user references after hard delete
- Uses grey placeholder avatar with `person_off` icon

## Components Updated
- **EventLeadComponent**: "Hosted by Former member" for orphaned standalone events
- **EventSeriesPage**: "Created by Former member" for orphaned series
- **GroupLeadComponent**: "Organized by former member" for groups with deleted creator
- **GroupAboutMembersComponent**: Placeholder avatar for deleted organizer

## Screenshots
N/A - only shows when user is deleted (can test after API PR merged)

## Test Plan
- [x] Merge API PR #456 first
- [ ] Delete a test user who owns events/groups
- [ ] Verify "Former member" appears instead of crash/blank

## Related
- **Backend PR:** OpenMeet-Team/openmeet-api#456
- This is a companion PR - merge API first, then this