### PR TITLE
fix(auth): redirect to home after account deletion

### DIFF
--- a/src/components/dashboard/DashboardProfileForm.vue
+++ b/src/components/dashboard/DashboardProfileForm.vue
@@ -277,6 +277,7 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
+import { useRouter } from 'vue-router'
 import { Dialog, LoadingBar } from 'quasar'
 import { authApi } from '../../api/auth'
 import { useAuthStore } from '../../stores/auth-store'
@@ -289,6 +290,7 @@ import { Profile } from '../../types/user'
 import { getImageSrc } from '../../utils/imageUtils'
 import CalendarConnectionsComponent from '../calendar/CalendarConnectionsComponent.vue'
 
+const router = useRouter()
 const { error, success } = useNotification()
 
 const form = ref<Profile>({
@@ -530,7 +532,10 @@ const onDeleteAccount = () => {
       color: 'negative'
     }
   }).onOk(() => {
-    authApi.deleteMe().then(() => useAuthStore().actionLogout())
+    authApi.deleteMe().then(async () => {
+      await useAuthStore().actionLogout()
+      router.push('/')
+    })
   })
 }
 


### PR DESCRIPTION
## Summary
- After successfully deleting an account, the page now redirects to the home page
- Previously, the page stayed on the profile settings even though the user was logged out

## Test plan
- [x] Log in and go to profile settings
- [x] Click "Delete my account" and confirm
- [x] Verify you are redirected to the home page after deletion