### PR TITLE
feat(atproto): add Take Ownership UI with password reset form

### DIFF
--- a/src/api/atproto.ts
+++ b/src/api/atproto.ts
@@ -1,6 +1,6 @@
 import { AxiosResponse } from 'axios'
 import { api } from '../boot/axios'
-import type { AtprotoIdentityDto, AtprotoRecoveryStatusDto } from '../types/atproto'
+import type { AtprotoIdentityDto, AtprotoRecoveryStatusDto, TakeOwnershipInitiateResponseDto } from '../types/atproto'
 
 const BASE_URL = '/api/atproto'
 
@@ -27,5 +27,29 @@ export const atprotoApi = {
    * Recover existing AT Protocol identity as custodial (OpenMeet manages credentials)
    */
   recoverAsCustodial: (): Promise<AxiosResponse<AtprotoIdentityDto>> =>
-    api.post(`${BASE_URL}/identity/recover-as-custodial`)
+    api.post(`${BASE_URL}/identity/recover-as-custodial`),
+
+  /**
+   * Initiate take ownership flow - sends PDS password reset email
+   * @returns The email address where the password reset was sent
+   */
+  initiateTakeOwnership: (): Promise<AxiosResponse<TakeOwnershipInitiateResponseDto>> =>
+    api.post(`${BASE_URL}/identity/take-ownership/initiate`),
+
+  /**
+   * Complete take ownership flow - marks identity as non-custodial
+   * @returns Success status
+   */
+  completeTakeOwnership: (): Promise<AxiosResponse<{ success: boolean }>> =>
+    api.post(`${BASE_URL}/identity/take-ownership/complete`),
+
+  /**
+   * Reset PDS password using the token from the password reset email
+   * This calls the PDS directly via our backend proxy
+   * @param token - The reset token from the email
+   * @param password - The new password
+   * @returns Success status
+   */
+  resetPdsPassword: (token: string, password: string): Promise<AxiosResponse<{ success: boolean }>> =>
+    api.post(`${BASE_URL}/identity/reset-pds-password`, { token, password })
 }

--- a/src/types/atproto.ts
+++ b/src/types/atproto.ts
@@ -27,3 +27,11 @@ export interface AtprotoRecoveryStatusDto {
   /** Whether the user has an existing AT Protocol account that can be recovered */
   hasExistingAccount: boolean
 }
+
+/**
+ * Response from initiating take ownership flow
+ */
+export interface TakeOwnershipInitiateResponseDto {
+  /** The email address where the password reset was sent */
+  email: string
+}


### PR DESCRIPTION
## Summary
- Add Take Ownership button for users with custodial AT Protocol identities
- Add inline password reset form (token, password, confirm) 
- Mobile-friendly design with full-width inputs and proper keyboard types
- Client-side validation (min 8 chars, passwords must match)

## Changes
- `src/api/atproto.ts` - Add initiateTakeOwnership, completeTakeOwnership, resetPdsPassword methods
- `src/components/atproto/AtprotoIdentityCard.vue` - Add take ownership UI with password form
- `src/components/dashboard/DashboardProfileForm.vue` - Handle new events
- `src/types/atproto.ts` - Add TakeOwnershipInitiateResponseDto

## Test plan
- [x] 18 new unit tests added and passing
- [x] Manual test: Click "Take Ownership", enter reset code from email, set password
- [ ] Manual test: Verify mobile layout works correctly

## Related
- Closes: om-uvzg
- Requires API PR: OpenMeet-Team/openmeet-api#475