### PR TITLE
feat(atproto): add Connect AT Protocol Account button and inline handle editing

### DIFF
--- a/src/components/dashboard/DashboardProfileForm.vue
+++ b/src/components/dashboard/DashboardProfileForm.vue
@@ -337,7 +337,7 @@ const passwordResetError = ref('')
 // Handle change state
 const updatingHandle = ref(false)
 const handleError = ref('')
-const handleDomain = ref('.opnmt.me') // TODO: get from config
+const handleDomain = computed(() => atprotoIdentity.value?.validHandleDomains?.[0] || '.opnmt.me')
 
 // Link external account state
 const linking = ref(false)

--- a/src/components/dashboard/__tests__/DashboardProfileForm.vitest.spec.ts
+++ b/src/components/dashboard/__tests__/DashboardProfileForm.vitest.spec.ts
@@ -94,6 +94,7 @@ describe('DashboardProfileForm', () => {
     isCustodial: false,
     isOurPds: false,
     hasActiveSession: false,
+    validHandleDomains: ['.bsky.social'],
     createdAt: new Date('2025-01-01'),
     updatedAt: new Date('2025-01-01'),
     ...overrides

--- a/src/types/atproto.ts
+++ b/src/types/atproto.ts
@@ -15,6 +15,8 @@ export interface AtprotoIdentityDto {
   isOurPds: boolean
   /** Whether this identity has an active session for publishing */
   hasActiveSession: boolean
+  /** Valid handle domains for this PDS (e.g., [".bsky.dev.openmeet.net"]) */
+  validHandleDomains: string[]
   /** When the identity was created */
   createdAt: Date
   /** When the identity was last updated */


### PR DESCRIPTION
## Summary

- Add "Connect AT Protocol Account" button for users to link their existing AT Protocol identity
- Move handle editing to inline icon `[✎]` next to handle display (cleaner UX)
- Replace verbose numbered take-ownership instructions with compact "Options" section
- Use `validHandleDomains` from API response instead of hardcoded `.opnmt.me`

## Changes

| User State | Handle Edit | Take Ownership | Connect AT Protocol | Create |
|------------|-------------|----------------|---------------------|--------|
| No identity | ❌ | ❌ | ✅ | ✅ |
| Custodial (our PDS) | ✅ | ✅ | ✅ | ❌ |
| Linked (our PDS) | ✅ | ❌ | ❌ | ❌ |
| Linked (external PDS) | ❌ | ❌ | ❌ | ❌ |

## Test plan

- [x] Unit tests pass (66 tests in AtprotoIdentityCard, 663 total)
- [x] Type check passes (`vue-tsc --noEmit`)
- [ ] Manual test: No identity state shows both Create and Connect buttons
- [ ] Manual test: Custodial user sees inline handle edit icon and Options section
- [x] Manual test: Handle domain suffix comes from API (not hardcoded)

Closes om-worf