### PR TITLE
fix(atproto): remove publish action from event badge

### DIFF
--- a/src/pages/EventPage.vue
+++ b/src/pages/EventPage.vue
@@ -381,25 +381,17 @@
                     {{ event.sourceType }}
                   </q-badge>
                   <q-badge
-                    v-if="canPublish"
-                    :color="publishStatus === 'syncing' ? 'grey' : publishStatus === 'error' ? 'negative' : 'warning'"
-                    class="q-ml-sm cursor-pointer"
-                    data-cy="publish-atproto-chip"
-                    :clickable="publishStatus !== 'syncing'"
-                    @click.stop.prevent="handlePublish"
+                    v-if="showNotPublishedBadge"
+                    color="grey"
+                    class="q-ml-sm"
+                    data-cy="not-published-badge"
                   >
-                    <q-spinner-dots
-                      v-if="publishStatus === 'syncing'"
-                      size="xs"
-                      class="q-mr-xs"
-                    />
                     <q-icon
-                      v-else
-                      :name="publishStatus === 'error' ? 'sym_r_error' : 'sym_r_cloud_off'"
+                      name="fa-solid fa-at"
                       size="xs"
                       class="q-mr-xs"
                     />
-                    {{ publishStatus === 'syncing' ? 'Publishing...' : publishStatus === 'error' ? 'Publish failed' : 'Not published' }}
+                    Not published
                   </q-badge>
                   <a
                     v-if="event.atprotoUri"
@@ -806,25 +798,17 @@
                       {{ event.sourceType }}
                     </q-badge>
                     <q-badge
-                      v-if="canPublish"
-                      :color="publishStatus === 'syncing' ? 'grey' : publishStatus === 'error' ? 'negative' : 'warning'"
-                      class="q-ml-sm cursor-pointer"
-                      data-cy="publish-atproto-chip"
-                      :clickable="publishStatus !== 'syncing'"
-                      @click.stop.prevent="handlePublish"
+                      v-if="showNotPublishedBadge"
+                      color="grey"
+                      class="q-ml-sm"
+                      data-cy="not-published-badge"
                     >
-                      <q-spinner-dots
-                        v-if="publishStatus === 'syncing'"
-                        size="xs"
-                        class="q-mr-xs"
-                      />
                       <q-icon
-                        v-else
-                        :name="publishStatus === 'error' ? 'sym_r_error' : 'sym_r_cloud_off'"
+                        name="fa-solid fa-at"
                         size="xs"
                         class="q-mr-xs"
                       />
-                      {{ publishStatus === 'syncing' ? 'Publishing...' : publishStatus === 'error' ? 'Publish failed' : 'Not published' }}
+                      Not published
                     </q-badge>
                     <a
                       v-if="event.atprotoUri"
@@ -1067,35 +1051,14 @@ import RecurrenceDisplayComponent from '../components/event/RecurrenceDisplayCom
 import { useAuthStore } from '../stores/auth-store'
 import { EventSeriesService } from '../services/eventSeriesService'
 
-// AT Protocol publishing state
-const publishStatus = ref<'idle' | 'syncing' | 'error'>('idle')
-
-const canPublish = computed(() => {
+// AT Protocol status display
+const showNotPublishedBadge = computed(() => {
   const authStore = useAuthStore()
   const hasActiveSession = authStore.user?.atprotoIdentity?.hasActiveSession === true
   const notAlreadyPublished = !event.value?.atprotoUri
   const notImported = !event.value?.sourceType
   return hasActiveSession && notAlreadyPublished && notImported
 })
-
-const handlePublish = async () => {
-  if (publishStatus.value === 'syncing' || !event.value) return
-
-  publishStatus.value = 'syncing'
-  try {
-    const response = await eventsApi.syncAtproto(event.value.slug)
-    // Update the event in the store with the new atprotoUri
-    useEventStore().event = response.data
-    publishStatus.value = 'idle'
-    $q.notify({ type: 'positive', message: 'Event published to AT Protocol' })
-  } catch (error) {
-    publishStatus.value = 'error'
-    $q.notify({ type: 'negative', message: 'Failed to publish event' })
-    setTimeout(() => {
-      publishStatus.value = 'idle'
-    }, 3000)
-  }
-}
 import dateFormatting from '../composables/useDateFormatting'
 import { eventLoadingState } from '../utils/eventLoadingState'
 import { useContactEventOrganizersDialog } from '../composables/useContactEventOrganizersDialog'


### PR DESCRIPTION
## Summary
- Remove click-to-publish functionality from ATProto status badges
- Badges now serve as status indicators only (grey "Not published", blue "Published")
- Uses consistent @ icon for both states

## Changes
- `EventsItemComponent.vue`: Simplified badge to status-only
- `EventPage.vue`: Same simplification (both desktop/mobile layouts)
- Updated tests

## Test plan
- [x] Unit tests pass (13 tests)
- [ ] Verify grey "Not published" badge appears for unpublished events
- [ ] Verify blue "Published" badge appears for published events
- [ ] Verify badges are not clickable

Related: om-kxiq