### PR TITLE
feat(atproto): simplify AT Protocol badges and add pds.ls links

### DIFF
--- a/src/components/event/__tests__/EventsItemComponent.vitest.spec.ts
+++ b/src/components/event/__tests__/EventsItemComponent.vitest.spec.ts
@@ -254,8 +254,8 @@ describe('EventsItemComponent', () => {
     })
   })
 
-  describe('"Published" badge visibility', () => {
-    it('should show "Published" badge when event has atprotoUri', () => {
+  describe('AT Protocol link visibility', () => {
+    it('should show AT Protocol link when event has atprotoUri', () => {
       const wrapper = mountComponent(
         {
           event: createMockEvent({
@@ -281,9 +281,9 @@ describe('EventsItemComponent', () => {
         }
       )
 
-      const badge = wrapper.find('[data-cy="event-atproto-badge"]')
-      expect(badge.exists()).toBe(true)
-      expect(badge.text()).toContain('Published')
+      const link = wrapper.find('[data-cy="event-atproto-link"]')
+      expect(link.exists()).toBe(true)
+      expect(link.attributes('href')).toBe('https://pds.ls/at://did:plc:test/community.lexicon.calendar.event/123')
     })
   })
 })

--- a/test/vitest/__tests__/components/event/EventsItemComponent.test.ts
+++ b/test/vitest/__tests__/components/event/EventsItemComponent.test.ts
@@ -48,8 +48,8 @@ describe('EventsItemComponent.vue', () => {
     vi.clearAllMocks()
   })
 
-  describe('AT Protocol Published Badge', () => {
-    it('displays AT Protocol badge when atprotoUri is present', () => {
+  describe('AT Protocol Link', () => {
+    it('displays AT Protocol link when atprotoUri is present', () => {
       const event = createMockEvent({
         atprotoUri: 'at://did:plc:abc123/community.openmeet.event/xyz789'
       })
@@ -71,12 +71,13 @@ describe('EventsItemComponent.vue', () => {
         }
       })
 
-      // Find the AT Protocol badge by data-cy attribute
-      const atprotoBadge = wrapper.find('[data-cy="event-atproto-badge"]')
-      expect(atprotoBadge.exists()).toBe(true)
+      // Find the AT Protocol link by data-cy attribute
+      const atprotoLink = wrapper.find('[data-cy="event-atproto-link"]')
+      expect(atprotoLink.exists()).toBe(true)
+      expect(atprotoLink.attributes('href')).toBe('https://pds.ls/at://did:plc:abc123/community.openmeet.event/xyz789')
     })
 
-    it('does not display AT Protocol badge when atprotoUri is null', () => {
+    it('does not display AT Protocol link when atprotoUri is null', () => {
       const event = createMockEvent({
         atprotoUri: undefined
       })
@@ -98,11 +99,11 @@ describe('EventsItemComponent.vue', () => {
         }
       })
 
-      const atprotoBadge = wrapper.find('[data-cy="event-atproto-badge"]')
-      expect(atprotoBadge.exists()).toBe(false)
+      const atprotoLink = wrapper.find('[data-cy="event-atproto-link"]')
+      expect(atprotoLink.exists()).toBe(false)
     })
 
-    it('does not display AT Protocol badge when atprotoUri is empty string', () => {
+    it('does not display AT Protocol link when atprotoUri is empty string', () => {
       const event = createMockEvent({
         atprotoUri: ''
       })
@@ -124,15 +125,12 @@ describe('EventsItemComponent.vue', () => {
         }
       })
 
-      const atprotoBadge = wrapper.find('[data-cy="event-atproto-badge"]')
-      expect(atprotoBadge.exists()).toBe(false)
+      const atprotoLink = wrapper.find('[data-cy="event-atproto-link"]')
+      expect(atprotoLink.exists()).toBe(false)
     })
 
-    it('displays both sourceType bluesky badge and atprotoUri badge when both are present', () => {
-      // An event could be imported FROM bluesky (sourceType) AND published TO AT Protocol (atprotoUri)
-      // These are different concepts that can coexist
+    it('displays AT Protocol link for events with atprotoUri', () => {
       const event = createMockEvent({
-        sourceType: 'bluesky',
         atprotoUri: 'at://did:plc:abc123/community.openmeet.event/xyz789'
       })
 
@@ -153,15 +151,40 @@ describe('EventsItemComponent.vue', () => {
         }
       })
 
-      // Both badges should be present
-      const atprotoBadge = wrapper.find('[data-cy="event-atproto-badge"]')
-      const sourceTypeBadge = wrapper.find('[data-cy="event-source-badge"]')
-
-      expect(atprotoBadge.exists()).toBe(true)
-      expect(sourceTypeBadge.exists()).toBe(true)
+      const atprotoLink = wrapper.find('[data-cy="event-atproto-link"]')
+      expect(atprotoLink.exists()).toBe(true)
+      expect(atprotoLink.attributes('href')).toBe('https://pds.ls/at://did:plc:abc123/community.openmeet.event/xyz789')
     })
 
-    it('displays AT Protocol badge with @ icon', () => {
+    it('displays AT Protocol link for imported bluesky events using sourceId', () => {
+      const event = createMockEvent({
+        sourceType: 'bluesky',
+        sourceId: 'at://did:plc:imported123/app.bsky.feed.post/abc789'
+      })
+
+      const wrapper = shallowMount(EventsItemComponent, {
+        props: { event },
+        global: {
+          stubs: {
+            'router-link': {
+              template: '<a><slot /></a>'
+            },
+            'q-img': true,
+            'q-badge': {
+              template: '<span class="q-badge" :color="$attrs.color"><slot /></span>',
+              inheritAttrs: true
+            },
+            'q-icon': true
+          }
+        }
+      })
+
+      const atprotoLink = wrapper.find('[data-cy="event-atproto-link"]')
+      expect(atprotoLink.exists()).toBe(true)
+      expect(atprotoLink.attributes('href')).toBe('https://pds.ls/at://did:plc:imported123/app.bsky.feed.post/abc789')
+    })
+
+    it('displays AT Protocol link with @ icon', () => {
       const event = createMockEvent({
         atprotoUri: 'at://did:plc:abc123/community.openmeet.event/xyz789'
       })
@@ -185,11 +208,11 @@ describe('EventsItemComponent.vue', () => {
         }
       })
 
-      const atprotoBadge = wrapper.find('[data-cy="event-atproto-badge"]')
-      expect(atprotoBadge.exists()).toBe(true)
+      const atprotoLink = wrapper.find('[data-cy="event-atproto-link"]')
+      expect(atprotoLink.exists()).toBe(true)
 
-      // Check for the @ icon within the badge (fa-at for AT Protocol)
-      const icon = atprotoBadge.find('[data-icon="fa-solid fa-at"]')
+      // Check for the @ icon within the link (fa-at for AT Protocol)
+      const icon = atprotoLink.find('[data-icon="fa-solid fa-at"]')
       expect(icon.exists()).toBe(true)
     })
   })


### PR DESCRIPTION
## Summary
- Remove "bluesky" source badge (butterfly icon) - transitioning to AT Protocol terminology
- Remove "Published" badge - being on AT Protocol should be the default state
- Keep "Not published" badge for events NOT on AT Protocol
- Add "@" icon link to pds.ls for viewing AT Protocol records

## Changes

**Removed:**
- `bluesky` source badge with butterfly icon
- `Published` badge (blue with @ icon)

**Kept:**
- `Not published` badge (grey) - only shown to users with AT Protocol session for events not on AT Protocol

**Added:**
- Small "@" icon that links to `https://pds.ls/{atprotoUri}` for viewing the AT Protocol record
- Shows for events with `atprotoUri` (published by OpenMeet) or `sourceId` with `sourceType='bluesky'` (imported)

## Philosophy
All events should eventually be on AT Protocol, so we flag the exceptions (not published) rather than the norm (published).

## Test plan
- [x] All 679 unit tests pass
- [ ] Manual test: verify "@" link appears for AT Protocol events and links to pds.ls
- [ ] Manual test: verify "Not published" badge appears only for events not on AT Protocol