### PR TITLE
fix(atproto): handle input dialog for account linking

### DIFF
--- a/src/components/atproto/AtprotoIdentityCard.vue
+++ b/src/components/atproto/AtprotoIdentityCard.vue
@@ -220,6 +220,24 @@
             </a>
           </div>
 
+          <!-- Options for connected non-custodial identity -->
+          <template v-if="!identity.isCustodial && identity.hasActiveSession">
+            <q-separator class="q-my-md" />
+            <div class="q-mt-md">
+              <div class="text-subtitle2 text-grey-7 q-mb-sm">Options</div>
+              <q-btn
+                data-cy="connect-different-btn"
+                color="secondary"
+                no-caps
+                outline
+                @click="$emit('link')"
+              >
+                <q-icon name="sym_r_swap_horiz" class="q-mr-sm" />
+                Connect Different Account
+              </q-btn>
+            </div>
+          </template>
+
           <!-- Options section for custodial identities on our PDS -->
           <template v-if="identity.isCustodial && identity.isOurPds">
             <q-separator class="q-my-md" />

--- a/src/components/atproto/__tests__/AtprotoIdentityCard.vitest.spec.ts
+++ b/src/components/atproto/__tests__/AtprotoIdentityCard.vitest.spec.ts
@@ -979,4 +979,70 @@ describe('AtprotoIdentityCard', () => {
       expect(button.exists()).toBe(false)
     })
   })
+
+  describe('Connect Different Account button for non-custodial with active session', () => {
+    it('should show "Connect Different Account" button for non-custodial identity with active session on our PDS', () => {
+      const identity = createMockIdentity({
+        isCustodial: false,
+        isOurPds: true,
+        hasActiveSession: true
+      })
+      const wrapper = mountComponent({ identity })
+
+      const button = wrapper.find('[data-cy="connect-different-btn"]')
+      expect(button.exists()).toBe(true)
+      expect(button.text()).toContain('Connect Different Account')
+    })
+
+    it('should show "Connect Different Account" button for non-custodial identity with active session on external PDS', () => {
+      const identity = createMockIdentity({
+        isCustodial: false,
+        isOurPds: false,
+        hasActiveSession: true
+      })
+      const wrapper = mountComponent({ identity })
+
+      const button = wrapper.find('[data-cy="connect-different-btn"]')
+      expect(button.exists()).toBe(true)
+      expect(button.text()).toContain('Connect Different Account')
+    })
+
+    it('should emit link event when "Connect Different Account" button is clicked', async () => {
+      const identity = createMockIdentity({
+        isCustodial: false,
+        isOurPds: true,
+        hasActiveSession: true
+      })
+      const wrapper = mountComponent({ identity })
+
+      const button = wrapper.find('[data-cy="connect-different-btn"]')
+      await button.trigger('click')
+
+      expect(wrapper.emitted('link')).toBeTruthy()
+    })
+
+    it('should NOT show "Connect Different Account" button for custodial identity', () => {
+      const identity = createMockIdentity({
+        isCustodial: true,
+        isOurPds: true,
+        hasActiveSession: false
+      })
+      const wrapper = mountComponent({ identity })
+
+      const button = wrapper.find('[data-cy="connect-different-btn"]')
+      expect(button.exists()).toBe(false)
+    })
+
+    it('should NOT show "Connect Different Account" button for non-custodial identity without active session', () => {
+      const identity = createMockIdentity({
+        isCustodial: false,
+        isOurPds: true,
+        hasActiveSession: false
+      })
+      const wrapper = mountComponent({ identity })
+
+      const button = wrapper.find('[data-cy="connect-different-btn"]')
+      expect(button.exists()).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- **om-lghy**: "Connect AT Protocol Account" button now opens a handle input dialog instead of auto-linking to the custodial identity. Users can enter any ATProto handle (e.g. `alice.bsky.social`) to initiate OAuth linking. The take-ownership auto-flow still bypasses the dialog by passing the handle directly.
- **om-13fx**: Added "Connect Different Account" button for users who already have a linked non-custodial identity with an active session, allowing them to switch to a different ATProto account.

## Changes

- `AtprotoIdentityCard.vue`: New "Connect Different Account" option section for connected non-custodial identities
- `DashboardProfileForm.vue`: `onLinkIdentity(handle?)` shows a `q-dialog` when no handle is provided; `submitLinkHandle()` calls the API with user-entered handle; `cancelLinkDialog()` resets state. Password reset auto-flow passes identity handle to skip the dialog.

## Test plan

- [x] 12 new unit tests (5 AtprotoIdentityCard, 7 DashboardProfileForm), all 89 passing
- [ ] Manual: Log in as user with custodial identity → Settings → Click "Connect AT Protocol Account" → Verify dialog appears with handle input
- [x] Manual: Enter a bsky.social handle → Click Connect → Verify redirect to PDS OAuth
- [ ] Manual: Log in as user with linked non-custodial identity → Verify "Connect Different Account" button appears
- [ ] Manual: Complete take-ownership flow → Verify auto-redirect to OAuth (no dialog)