### PR TITLE
fix(ui): prevent hero text overlap with floating profile bubbles

### DIFF
--- a/src/components/home/HomeHeroComponent.vue
+++ b/src/components/home/HomeHeroComponent.vue
@@ -124,6 +124,7 @@ const onJoinNowClick = () => {
   z-index: 1;
   text-align: center;
   width: 100%;
+  padding: 0 220px;
 }
 
 :deep(.q-btn) {
@@ -156,24 +157,13 @@ const onJoinNowClick = () => {
   .hero-content {
     margin-top: 32px !important;
     margin-bottom: 24px !important;
+    padding: 0 96px !important;
   }
 }
 
 @media (max-width: 600px) {
-  .bubble-wrapper-left,
-  .bubble-wrapper-right,
-  .profile-left,
-  .profile-right {
-    width: 90px !important;
-    height: 90px !important;
-  }
-  .bubble-left {
-    left: 8px !important;
-    bottom: 8px !important;
-  }
-  .bubble-right {
-    right: 8px !important;
-    top: 8px !important;
+  .floating-profiles {
+    display: none !important;
   }
   .hero-container {
     padding: 16px !important;
@@ -182,6 +172,7 @@ const onJoinNowClick = () => {
   .hero-content {
     margin-top: 24px !important;
     margin-bottom: 16px !important;
+    padding: 0 16px !important;
   }
 }
 </style>


### PR DESCRIPTION
## Summary
- Add horizontal padding to `.hero-content` so text doesn't flow under the absolutely-positioned profile bubbles
- At mobile (≤600px), hide floating profile bubbles entirely since container is too narrow
- Remove anomalous 90px mobile bubble sizing (was larger than 80px tablet size)

Fixes #375

## Test plan
- [x] Verified at desktop (>1024px) — text centered with clear space around bubbles
- [x] Verified at tablet (~800px) — text stays within padded area
- [x] Verified at mobile (~400px) — bubbles hidden, clean centered text