### PR TITLE
fix(api): restore Axios array param serialization for NestJS

### DIFF
--- a/src/boot/axios.ts
+++ b/src/boot/axios.ts
@@ -14,7 +14,11 @@ declare module 'vue' {
 }
 
 // Create api without baseURL initially
-const api = axios.create()
+// Axios 1.12+ defaults to bracket notation for arrays (categories[]=X).
+// NestJS expects repeated params (categories=X&categories=Y). Restore pre-1.12 behavior.
+const api = axios.create({
+  paramsSerializer: { indexes: null }
+})
 const { error } = useNotification()
 const { handlePotentialVersionError } = useVersionErrorHandling()
 


### PR DESCRIPTION
## Summary

- Axios 1.12+ changed default array serialization from repeated params (`categories=X&categories=Y`) to bracket notation (`categories[]=X&categories[]=Y`)
- NestJS query DTOs don't recognize bracket notation, so category filtering on the events page silently stopped working after the axios 1.9 to 1.12 bump in #222
- Sets `paramsSerializer: { indexes: null }` on the Axios instance to restore pre-1.12 behavior

## Test plan

- [x] Open /events page, select a category filter — only matching events should appear
- [x] Verify network tab shows `categories=Music` not `categories[]=Music`
- [ ] Verify other array query params (if any) still work