### PR TITLE
fix: update empty-state event button label for users with past events

### DIFF
--- a/src/pages/dashboard/DashboardEventsPage.vue
+++ b/src/pages/dashboard/DashboardEventsPage.vue
@@ -31,7 +31,7 @@
       <NoContentComponent
         v-if="!hasAnyEvents"
         @click="onAddNewEvent"
-        buttonLabel="Create your first event"
+        :buttonLabel="emptyEventButtonLabel"
         label="You don't have any upcoming events"
         icon="sym_r_event"
       />
@@ -197,6 +197,10 @@ const hasAnyEvents = computed(() => {
     summary.value.attendingSoon.length > 0
   )
 })
+
+const hasPastEvents = computed(() => Boolean(summary.value?.counts.past))
+
+const emptyEventButtonLabel = computed(() => hasPastEvents.value ? 'Create a new event' : 'Create your first event')
 
 const moreHostingCount = computed(() => {
   if (!summary.value) return 0


### PR DESCRIPTION
## Fix for "Create your first event" label shown for users with past events (#409)

Updated the empty state logic in DashboardEventsPage.vue to display the correct button label based on whether the user has past events.

Changed the button label from a static value to a computed property.

Added a computed check for past events using summary.counts.past.

Before fix:
- Button always showed "Create your first event"

After fix:
- Shows "Create your first event" when there are no past events
- Shows "Create a new event" when past events exist

Closes #409

Before fix :  
<img width="497" height="305" alt="image" src="https://github.com/user-attachments/assets/fbab4339-3ca5-4f4e-8ce2-3de110744324" />

After fix : 
<img width="512" height="314" alt="image" src="https://github.com/user-attachments/assets/977f81dc-9a57-4473-ba1a-8b5b7c902dcf" />