### PR TITLE
fix(axios): stop the 401 refresh-retry loop with a once-only guard

### DIFF
--- a/src/boot/axios.ts
+++ b/src/boot/axios.ts
@@ -96,6 +96,27 @@ export default boot(async ({ app, router }) => {
           return Promise.reject(err)
         }
 
+        // Once-only guard: if we already refreshed the token and retried this
+        // exact request and it STILL returns 401, retrying again
+        // would just replay it forever (the ~5 req/s self-DoS loop). A freshly
+        // refreshed token being rejected means the session is broken (revoked /
+        // wrong-audience / backend-rejected) — NOT a per-resource permission
+        // issue (those now return 403 and never reach here). Stop, and for an
+        // authenticated request re-authenticate, matching the refresh-failure
+        // path below (this also prevents a refresh storm from sibling requests).
+        if (originalRequest._retry) {
+          console.log('🔴 401 persisted after token refresh — session invalid, clearing auth (no retry):', originalRequest.url)
+          if (originalRequest.headers?.Authorization) {
+            authStore.actionClearAuth()
+            error('Your session is no longer valid. Please log in again.')
+            router.push({
+              name: 'AuthLoginPage',
+              query: { redirect: router.currentRoute.value.fullPath }
+            })
+          }
+          return Promise.reject(err)
+        }
+
         // Handle token refresh with cross-tab coordination
         if (authStore.refreshToken) {
           // Check if another tab is already refreshing
@@ -110,6 +131,7 @@ export default boot(async ({ app, router }) => {
               const updatedToken = authStore.token
               if (updatedToken && updatedToken !== originalRequest.headers.Authorization?.replace('Bearer ', '')) {
                 console.log('✅ Using refreshed token from another tab')
+                originalRequest._retry = true
                 originalRequest.headers.Authorization = `Bearer ${updatedToken}`
                 return api(originalRequest)
               }
@@ -130,6 +152,7 @@ export default boot(async ({ app, router }) => {
             const refreshCompleted = await crossTabTokenService.waitForRefresh(10000)
 
             if (refreshCompleted && authStore.token) {
+              originalRequest._retry = true
               originalRequest.headers.Authorization = `Bearer ${authStore.token}`
               return api(originalRequest)
             } else {
@@ -162,6 +185,7 @@ export default boot(async ({ app, router }) => {
             processQueue(null, newToken)
 
             // Retry the original request
+            originalRequest._retry = true
             originalRequest.headers.Authorization = `Bearer ${newToken}`
             return api(originalRequest)
           } catch (refreshError) {


### PR DESCRIPTION
## Problem

The response interceptor treats every 401 as an expired session: it refreshes
the token and replays the original request. When a refresh **succeeds** but the
replay still returns 401 (an authorization failure, not an expired token), the
request loops forever at ~5 req/s — a self-inflicted request storm that drove a
production error spike. The `_retry` flag was logged but never set or checked,
so nothing broke the loop.

## Fix

- Set `_retry = true` at all three post-refresh replay sites.
- Add a once-only guard: a second 401 after a successful refresh means the
  refreshed token is being rejected — the session is broken, not something to
  retry. Clear auth and route to re-login for authenticated requests (matching
  the existing refresh-failure handling), which also prevents sibling requests
  from storming.

Verified there are exactly three replay sites (all now guarded) and that the
`failedQueue` path is vestigial (nothing enqueues), so there is no unguarded
replay.

## Companion

The root cause is also fixed server-side in `openmeet-api` (branch
`fix/event-series-non-owner-403`), which returns 403 instead of 401 for the
ownership failure that triggered this. This guard is defense-in-depth for any
endpoint that legitimately 401s after a successful refresh.