### PR TITLE
Tell users what taking ownership of their AT Protocol account gives them

### DIFF
--- a/src/components/atproto/AtprotoIdentityCard.vue
+++ b/src/components/atproto/AtprotoIdentityCard.vue
@@ -246,6 +246,41 @@
           <!-- Options for connected non-custodial identity -->
           <template v-if="!identity.isCustodial && identity.hasActiveSession">
             <q-separator class="q-my-md" />
+
+            <!-- What the user now holds, and where else it works -->
+            <div class="q-mt-md" data-cy="account-ownership-note">
+              <!-- Only accounts we created can be described as handed over -->
+              <div v-if="identity.isOurPds" class="text-body2 q-mb-sm">
+                <strong>You own this account now.</strong> OpenMeet no longer holds its password. From now
+                on, use <strong>Sign in with AT Protocol or Bluesky</strong><span v-if="identity.handle"> with
+                your handle <strong>@{{ identity.handle }}</strong></span>: you don't need Google or your
+                OpenMeet email password anymore.
+              </div>
+              <div v-else class="text-body2 q-mb-sm">
+                <strong>This account is yours</strong>, hosted at <strong>{{ pdsHostname }}</strong>. You can
+                sign in to OpenMeet with it, and you don't need Google or your OpenMeet email password.
+              </div>
+              <div class="text-body2 text-grey-8">
+                Your account works in other AT Protocol apps too.
+                <a
+                  data-cy="atmo-link"
+                  href="https://atmo.rsvp"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-primary"
+                >atmo.rsvp</a>
+                is another event app: individual events, not groups.
+                <a
+                  data-cy="bsky-app-link"
+                  href="https://bsky.app"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="text-primary"
+                >bsky.app</a>
+                is Bluesky, the social app. Your events and RSVPs travel with your account.
+              </div>
+            </div>
+
             <div class="q-mt-md">
               <div class="text-subtitle2 text-grey-7 q-mb-sm">Options</div>
               <div class="q-gutter-sm">
@@ -279,7 +314,15 @@
 
             <!-- Normal state: show options -->
             <div v-if="!takeOwnershipPending" class="q-mt-md">
-              <div class="text-subtitle2 text-grey-7 q-mb-sm">Options</div>
+              <div class="text-subtitle2 q-mb-xs">Your AT Protocol account</div>
+              <div class="text-body2 text-grey-8 q-mb-xs">
+                OpenMeet made this account for you and still holds its password. Set your own AT Protocol
+                password and the account becomes yours: you'll sign in to OpenMeet with it, and you can use
+                it in other AT Protocol apps too.
+              </div>
+              <div class="text-caption text-grey-7 q-mb-sm">
+                This is separate from your OpenMeet password.
+              </div>
 
               <div class="row q-gutter-sm q-mb-md">
                 <q-btn
@@ -290,7 +333,7 @@
                   @click="$emit('initiate-take-ownership')"
                 >
                   <q-icon name="sym_r_key" class="q-mr-sm" />
-                  Take Ownership
+                  Make this AT Protocol account yours
                 </q-btn>
 
                 <q-btn
@@ -325,7 +368,10 @@
                 </template>
                 <div class="text-body2">
                   Check your email at <strong>{{ takeOwnershipEmail }}</strong> for a password reset code.
-                  Enter the code and your new password below.
+                  Enter the code and choose a password below.
+                  <div class="q-mt-sm">
+                    <strong>This is a new AT Protocol password</strong>, not your OpenMeet password.
+                  </div>
                 </div>
               </q-banner>
 
@@ -355,7 +401,7 @@
                 <q-input
                   data-cy="password-reset-password"
                   v-model="resetPassword"
-                  label="New Password"
+                  label="New AT Protocol Password"
                   hint="Must be at least 8 characters"
                   filled
                   :type="showPassword ? 'text' : 'password'"
@@ -374,7 +420,7 @@
                 <q-input
                   data-cy="password-reset-confirm"
                   v-model="resetPasswordConfirm"
-                  label="Confirm Password"
+                  label="Confirm AT Protocol Password"
                   filled
                   :type="showPassword ? 'text' : 'password'"
                   :error="!!validationErrors.confirm"
@@ -623,6 +669,16 @@ const statusColor = computed(() => {
   // Non-custodial: green if connected, warning if needs auth
   if (props.identity.hasActiveSession) return 'positive'
   return 'warning'
+})
+
+const pdsHostname = computed(() => {
+  if (!props.identity?.pdsUrl) return ''
+  try {
+    return new URL(props.identity.pdsUrl).hostname
+  } catch {
+    // pdsUrl is not guaranteed to parse; showing it raw beats showing nothing
+    return props.identity.pdsUrl
+  }
 })
 
 const blueskyProfileUrl = computed(() => {

--- a/src/components/atproto/__tests__/AtprotoIdentityCard.vitest.spec.ts
+++ b/src/components/atproto/__tests__/AtprotoIdentityCard.vitest.spec.ts
@@ -303,8 +303,57 @@ describe('AtprotoIdentityCard', () => {
     })
   })
 
+  describe('Account ownership note on the connected card', () => {
+    const connected = (overrides: Partial<AtprotoIdentityDto> = {}) => createMockIdentity({
+      isCustodial: false,
+      hasActiveSession: true,
+      ...overrides
+    })
+
+    it('tells a converted user on our PDS that OpenMeet no longer holds the password', () => {
+      const wrapper = mountComponent({ identity: connected({ isOurPds: true }) })
+
+      const note = wrapper.find('[data-cy="account-ownership-note"]')
+      expect(note.exists()).toBe(true)
+      expect(note.text()).toContain('You own this account now')
+      expect(note.text()).toContain('@alice.opnmt.me')
+    })
+
+    it('does NOT claim we handed over an account hosted on another PDS', () => {
+      const wrapper = mountComponent({
+        identity: connected({
+          isOurPds: false,
+          handle: 'alice.bsky.social',
+          pdsUrl: 'https://bsky.social'
+        })
+      })
+
+      const note = wrapper.find('[data-cy="account-ownership-note"]')
+      expect(note.text()).not.toContain('OpenMeet no longer holds')
+      expect(note.text()).toContain('This account is yours')
+      expect(note.text()).toContain('bsky.social')
+    })
+
+    it('offers both AT Protocol apps to either kind of connected user', () => {
+      for (const isOurPds of [true, false]) {
+        const wrapper = mountComponent({ identity: connected({ isOurPds }) })
+
+        expect(wrapper.find('[data-cy="atmo-link"]').attributes('href')).toBe('https://atmo.rsvp')
+        expect(wrapper.find('[data-cy="bsky-app-link"]').attributes('href')).toBe('https://bsky.app')
+      }
+    })
+
+    it('is not shown to a custodial user who has not converted yet', () => {
+      const wrapper = mountComponent({
+        identity: createMockIdentity({ isCustodial: true, isOurPds: true })
+      })
+
+      expect(wrapper.find('[data-cy="account-ownership-note"]').exists()).toBe(false)
+    })
+  })
+
   describe('Take ownership flow', () => {
-    it('should show "Take Ownership" button for custodial identity on our PDS', () => {
+    it('should show the take-ownership button for custodial identity on our PDS', () => {
       const identity = createMockIdentity({
         isCustodial: true,
         isOurPds: true
@@ -313,7 +362,7 @@ describe('AtprotoIdentityCard', () => {
 
       const button = wrapper.find('[data-cy="take-ownership-btn"]')
       expect(button.exists()).toBe(true)
-      expect(button.text()).toContain('Take Ownership')
+      expect(button.text()).toContain('Make this AT Protocol account yours')
     })
 
     it('should NOT show "Take Ownership" button for non-custodial identity', () => {
@@ -542,8 +591,8 @@ describe('AtprotoIdentityCard', () => {
       expect(passwordWrapper.exists()).toBe(true)
       expect(confirmWrapper.exists()).toBe(true)
       // Check labels are present
-      expect(wrapper.text()).toContain('New Password')
-      expect(wrapper.text()).toContain('Confirm Password')
+      expect(wrapper.text()).toContain('New AT Protocol Password')
+      expect(wrapper.text()).toContain('Confirm AT Protocol Password')
     })
 
     it('should show submit button for password reset', () => {

--- a/src/components/dashboard/DashboardProfileForm.vue
+++ b/src/components/dashboard/DashboardProfileForm.vue
@@ -687,7 +687,7 @@ const onResetPdsPassword = async (payload: { token: string; password: string }) 
     atprotoIdentity.value = response.data
     takeOwnershipPending.value = false
     takeOwnershipEmail.value = ''
-    success('Password set! Connecting your account...')
+    success('This AT Protocol account is yours. Signing you in...')
 
     // Auto-redirect to OAuth to complete the flow
     // This establishes the session so the user can publish


### PR DESCRIPTION
The AT Protocol identity card never explained why anyone would press the take-ownership button, and never named where the account works once they held it. A user finishes the hardest step in the flow and the card offers them two ways to undo it.

This is copy only. No behavior changes, no new flow, no forced path: a user who ignores the invitation keeps working exactly as they do today.

## What changed

**The invitation** (custodial identities on our PDS). The bare `Options` label becomes a heading and two sentences that state the trade, and the button names the benefit instead of the mechanism:

> **Your AT Protocol account**
> OpenMeet made this account for you and still holds its password. Set your own AT Protocol password and the account becomes yours: you'll sign in to OpenMeet with it, and you can use it in other AT Protocol apps too.
> *This is separate from your OpenMeet password.*

**The ask.** The reset banner and both password fields now say *which* password is being set. There are two passwords in play and the old copy did not distinguish them, which put it one line away from the ordinary set-a-password flow.

**Completion.** A new block on the connected card says what the user now holds and links two apps their account already works in, `atmo.rsvp` and `bsky.app`. The success toast names what happened rather than describing a reconnect.

## The one structural decision

The connected branch is `!isCustodial && hasActiveSession`, which also matches every user who arrived with their own Bluesky account. Telling them "OpenMeet no longer holds its password" would describe an account we never made.

So only the first sentence switches on `isOurPds`. The paragraph about other apps is shared, because it is equally true either way. One block, one conditional sentence.

## Testing

- Four new tests cover the note: both PDS cases, both links, and the negative case where a custodial user must not see it. Reverting the component makes three of the four fail. The fourth is a guard against a future widening of the condition and passes vacuously before the change, so it is not evidence on its own.
- Two existing assertions updated because the copy they asserted changed.
- `vue-tsc --noEmit` output is identical with and without this branch. The repository has pre-existing errors, almost all under `test/`; neither changed file contributes one.
- `npm run test:unit`: the same 5 files and 43 tests fail as on `main`, with 804 passing against 800.
- `eslint` clean on all three files.